### PR TITLE
fixes #219; adds example command to start the demo app

### DIFF
--- a/examples/ui/feed-app/Readme.md
+++ b/examples/ui/feed-app/Readme.md
@@ -3,4 +3,4 @@
 Please first follow the steps in the README.md file at the root of this repository.
 Once everything is set up, run `npm run start:feed-app` at the root of this repository.
 
-Happy coding, and remember that every update on plugins ts files or the events app will trigger an update.
+Happy coding, and remember that every update on plugins typescript files or the events app will trigger an update.


### PR DESCRIPTION
The current `Readme.md` file should provide an example command for starting the demo app.