### PR TITLE
 patch observers for current ethAddress

### DIFF
--- a/sdk-packages/auth/src/auth.service.ts
+++ b/sdk-packages/auth/src/auth.service.ts
@@ -52,7 +52,7 @@ const service: AkashaService = (invoke, log) => {
     const authAttachmentToken = await attachment.get({ id: 'auth_token', ethAddress: address });
     if (authAttachmentToken) {
       cache.set(AUTH_CACHE, { [ethAddressCache]: address, [tokenCache]: authAttachmentToken });
-      return authAttachmentToken;
+      return { token: authAttachmentToken, ethAddress: address };
     }
     const sig = await signer.signMessage(AUTH_MESSAGE);
     const token = await getJWT({ eth_address: address, signature: sig });

--- a/ui/widgets/login/src/state/index.ts
+++ b/ui/widgets/login/src/state/index.ts
@@ -40,7 +40,14 @@ export const loginStateModel: LoginStateModel = {
       errors: {},
     },
     {
-      blacklist: ['errors', 'providerListVisibility', 'learnMoreVisibility', 'selectedProvider'],
+      blacklist: [
+        'errors',
+        'providerListVisibility',
+        'learnMoreVisibility',
+        'selectedProvider',
+        // this doesn't play ok with global channels, will require a session api before enabling persist
+        'jwtToken',
+      ],
     },
   ),
   updateData: action((state, payload) => {

--- a/ui/widgets/top-bar/src/components/topbar-widget.tsx
+++ b/ui/widgets/top-bar/src/components/topbar-widget.tsx
@@ -92,6 +92,7 @@ export default class TopbarWidget extends PureComponent<IProps> {
                 navigateToUrl={this.props.singleSpa.navigateToUrl}
                 toggleSidebar={this.toggleSidebar}
                 getMenuItems={this.props.getMenuItems}
+                ethAddress={this.state.ethAddress}
                 loaderEvents={this.props.events}
               />
             </ViewportSizeProvider>
@@ -106,11 +107,12 @@ interface TopBarProps {
   navigateToUrl: (url: string) => void;
   toggleSidebar: (visible: boolean) => void;
   getMenuItems: () => IMenuItem[];
+  ethAddress: string;
   loaderEvents: any;
 }
 
 const TopbarComponent = (props: TopBarProps) => {
-  const { navigateToUrl, getMenuItems, loaderEvents, toggleSidebar } = props;
+  const { navigateToUrl, getMenuItems, loaderEvents, toggleSidebar, ethAddress } = props;
 
   const [currentMenu, setCurrentMenu] = React.useState<IMenuItem[]>([]);
 
@@ -161,7 +163,7 @@ const TopbarComponent = (props: TopBarProps) => {
         onNavigation={handleNavigation}
         onSearch={handleSearchBarKeyDown}
         onSidebarToggle={toggleSidebar}
-        ethAddress="0x1ad35f55220234DF32A"
+        ethAddress={ethAddress}
         quickAccessItems={quickAccessItems}
         searchAreaItem={searchAreaItem}
         size={size}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add observer for ethAddress in topbar, fixed an issue with current ethAddress from sdk cache and removed persistence for jwt from login widget

## Issues that will be closed
Closes #500
Closes #501

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
