### PR TITLE
Public transparency log for moderation

### DIFF
--- a/api/hub/src/api.ts
+++ b/api/hub/src/api.ts
@@ -298,6 +298,18 @@ api.post('/moderation/decisions/moderated', async (ctx: koa.Context, next: () =>
 });
 
 /**
+ * Get a public log of all content that has been moderated, for transparency purposes.
+ */
+api.post('/moderation/decisions/log', async (ctx: koa.Context, next: () => Promise<any>) => {
+  const req = ctx?.request.body;
+  ctx.body = await dataSources.decisionsAPI.publicLog(req.offset, req.limit);
+  ctx.set('Content-Type', 'application/json');
+  ctx.status = 200;
+
+  await next();
+});
+
+/**
  * Add a new moderator.
  */
 api.post('/moderation/moderators/new', async (ctx: koa.Context, next: () => Promise<any>) => {


### PR DESCRIPTION
Adds public transparency log for moderation.

## Description

The public transparency log is used to hold moderators accountable for their actions, since everyone will be able to see what content was moderated and by whom.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
