### PR TITLE
Added missing number of reports for moderated content

### DIFF
--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -179,6 +179,7 @@ class ModerationDecisionAPI extends DataSource {
         },
         delisted: decision.delisted,
         reasons: decision.reasons,
+        reports: decision.reports,
         explanation: decision.explanation,
       });
     }


### PR DESCRIPTION
Quick fix to add missing property to the transparency log.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
