### PR TITLE
fix: action log backwards compatibility

### DIFF
--- a/api/hub/src/api.ts
+++ b/api/hub/src/api.ts
@@ -370,30 +370,14 @@ api.post('/moderation/decisions/log', async (ctx: koa.Context, next: () => Promi
  * Get a log of all moderation actions for a given content identifier.
  */
 api.get('/moderation/decisions/actions/:contentId', async (ctx: koa.Context, next: () => Promise<any>) => {
-  const req = ctx?.request.body;
   const contentID = ctx?.params?.contentId;
-  if (!contentID || !req.data || !req.signature) {
+  if (!contentID) {
     ctx.body = 'Missing "contentId" attribute from request.';
     ctx.status = 400;
   } else {
-    // check if the user is local (exists)
-    const profile = await dataSources.profileAPI.getProfile(req.data.moderator);
-    if (!profile.length || !req.data.signature) {
-      ctx.status = 401;
-    }
-    // verify request signature (from client)
-    const verified = await verifyEd25519Sig({
-      pubKey: profile.pubKey,
-      data: req.data,
-      signature: req.signature,
-    });
-    if (!verified) {
-      ctx.status = 403;
-    } else {
-      ctx.body = await dataSources.decisionsAPI.listActions(contentID);
-      ctx.set('Content-Type', 'application/json');
-      ctx.status = 200;
-    }
+    ctx.body = await dataSources.decisionsAPI.listActions(contentID);
+    ctx.set('Content-Type', 'application/json');
+    ctx.status = 200;
   }
   await next();
 });

--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -132,7 +132,7 @@ class ModerationDecisionAPI extends DataSource {
    */
   async listActions(contentID: string) {
     let decision = parse(stringify(await this.getDecision(contentID)));
-    if (decision.actions && decision.actions.length > 0) {
+    if (decision.actions && decision.actions.length) {
       decision.actions.forEach((element, index) => {
         element.explanation = decodeString(element.explanation);
         decision.actions[index] = element;

--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -132,7 +132,7 @@ class ModerationDecisionAPI extends DataSource {
    */
   async listActions(contentID: string) {
     let decision = parse(stringify(await this.getDecision(contentID)));
-    if (decision.actions) {
+    if (decision.actions && decision.actions.length > 0) {
       decision.actions.forEach((element, index) => {
         element.explanation = decodeString(element.explanation);
         decision.actions[index] = element;

--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -132,10 +132,12 @@ class ModerationDecisionAPI extends DataSource {
    */
   async listActions(contentID: string) {
     let decision = parse(stringify(await this.getDecision(contentID)));
-    decision.actions.forEach((element, index) => {
-      element.explanation = decodeString(element.explanation);
-      decision.actions[index] = element;
-    });
+    if (decision.actions) {
+      decision.actions.forEach((element, index) => {
+        element.explanation = decodeString(element.explanation);
+        decision.actions[index] = element;
+      });
+    }
     return decision;
   }
 


### PR DESCRIPTION
This fix makes sure there are no errors when trying to get the action for (old) moderated content that doesn't have the `actions` property.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
