### PR TITLE
feat: also return reported reason when checking moderation status

### DIFF
--- a/api/hub/src/api.ts
+++ b/api/hub/src/api.ts
@@ -8,7 +8,6 @@ import ModerationReportAPI from './datasources/moderation-report';
 import ModerationDecisionAPI from './datasources/moderation-decision';
 import ModerationAdminAPI from './datasources/moderation-admin';
 import ModerationReasonAPI from './datasources/moderation-reasons';
-import { statSync } from 'fs';
 // import { Invite } from './collections/interfaces';
 
 export const promRegistry = new promClient.Registry();

--- a/api/hub/src/api.ts
+++ b/api/hub/src/api.ts
@@ -8,6 +8,7 @@ import ModerationReportAPI from './datasources/moderation-report';
 import ModerationDecisionAPI from './datasources/moderation-decision';
 import ModerationAdminAPI from './datasources/moderation-admin';
 import ModerationReasonAPI from './datasources/moderation-reasons';
+import { statSync } from 'fs';
 // import { Invite } from './collections/interfaces';
 
 export const promRegistry = new promClient.Registry();
@@ -208,6 +209,7 @@ api.post('/moderation/status', async (ctx: koa.Context, next: () => Promise<any>
         reported: false,
         moderated: false,
         delisted: false,
+        reason: '',
       };
       // get decision for the current contentID
       const decision = await dataSources.decisionsAPI.getDecision(contentID);
@@ -219,6 +221,7 @@ api.post('/moderation/status', async (ctx: koa.Context, next: () => Promise<any>
           const reported = await dataSources.reportingAPI.getReport(contentID, body.user);
           if (reported) {
             status.reported = true;
+            status.reason = reported.reason;
           }
         }
       }


### PR DESCRIPTION
This PR adds an extra attribute to the data returned by the moderation API. It is required by the new design screens when checking if content was reported by the same user.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
