### PR TITLE
Feat: moderation notifications and pubKey refactor

### DIFF
--- a/api/hub/src/collections/interfaces.ts
+++ b/api/hub/src/collections/interfaces.ts
@@ -63,7 +63,6 @@ export interface Invite {
 export interface Moderator {
   _id: string;
   creationDate: number;
-  ethAddress: string;
   admin: boolean;
   active: boolean;
 }

--- a/api/hub/src/collections/moderators.ts
+++ b/api/hub/src/collections/moderators.ts
@@ -4,11 +4,10 @@ import { Moderator } from './interfaces';
 const schema = {
   title: 'Moderator',
   type: 'object',
-  required: ['_id', 'ethAddress', 'admin', 'active'],
+  required: ['_id', 'admin', 'active'],
   properties: {
     _id: { type: 'string' },
     creationDate: { type: 'number' },
-    ethAddress: { type: 'string' },
     admin: { type: 'boolean' },
     active: { type: 'boolean' },
   },
@@ -22,16 +21,8 @@ const readFilter = (reader: string, instance: Moderator) => {
   return instance;
 };
 
-const indexes = [
-  {
-    path: 'ethAddress',
-    unique: true,
-  },
-  {
-    path: 'creationDate',
-    unique: false,
-  },
-];
+const indexes = [];
+
 export function newCollection(client: Client, threadID: ThreadID) {
   return client.newCollection(threadID, {
     schema,

--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -204,8 +204,7 @@ class ModerationDecisionAPI extends DataSource {
       const decision = await this.getFinalDecision(result.contentID);
       // load moderator info
       const profileAPI = new ProfileAPI({ dbID: this.dbID, collection: 'Profiles' });
-      const moderator = decision.moderator.startsWith('0x') ? 
-      await profileAPI.getProfile(decision.moderator) : await profileAPI.resolveProfile(decision.moderator);
+      const moderator = await profileAPI.resolveProfile(decision.moderator);
 
       moderated.push({
         contentID: decision.contentID,

--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -315,6 +315,8 @@ class ModerationDecisionAPI extends DataSource {
         notificationType = 'MODERATED_REPLY';
       } else if (decision.contentType == 'account') {
         notificationType = 'MODEREATED_ACCOUNT';
+        const account = await profileAPI.getProfile(contentID);
+        contentID = account.pubKey;
       }
       await sendAuthorNotification(moderatorProfile.pubKey, {
         property: notificationType,

--- a/ui/design/src/components/NotificationCard/NotificationCard.stories.tsx
+++ b/ui/design/src/components/NotificationCard/NotificationCard.stories.tsx
@@ -56,5 +56,8 @@ BaseNotificationCard.args = {
   followingLabel: 'is now following you',
   mentionedPostLabel: 'mentioned you in a post',
   mentionedCommentLabel: 'mentioned you in a comment',
+  moderatedPostLabel: 'moderated your post',
+  moderatedReplyLabel: 'moderated your reply',
+  moderatedAccountLabel: 'suspended your account',
   emptySubtitle: "You don't have any new notifications!",
 };

--- a/ui/design/src/components/NotificationCard/index.tsx
+++ b/ui/design/src/components/NotificationCard/index.tsx
@@ -22,6 +22,9 @@ export interface INotificationsCard {
   repostLabel?: string;
   replyLabel?: string;
   markAsReadLabel?: string;
+  moderatedPostLabel?: string;
+  moderatedReplyLabel?: string;
+  moderatedAccountLabel?: string;
   emptyTitle?: string;
   emptySubtitle?: string;
   // handlers
@@ -41,6 +44,9 @@ const NotificationsCard: React.FC<INotificationsCard> = props => {
     mentionedCommentLabel,
     replyLabel,
     repostLabel,
+    moderatedPostLabel,
+    moderatedReplyLabel,
+    moderatedAccountLabel,
     markAsReadLabel,
     emptyTitle,
     emptySubtitle,
@@ -64,6 +70,7 @@ const NotificationsCard: React.FC<INotificationsCard> = props => {
     const postID = Array.isArray(notif.body?.value?.postID)
       ? notif.body?.value?.postID[0]
       : notif.body?.value?.postID;
+    const moderatedID = notif.body?.value?.contentID;
     // use this when we have routing available for comments
     // const commentID = Array.isArray(notif.body?.value?.commentID)
     //   ? notif.body?.value?.commentID[0]
@@ -112,6 +119,34 @@ const NotificationsCard: React.FC<INotificationsCard> = props => {
           handleProfileClick(profileData.pubKey);
         };
         break;
+      case 'MODERATED_POST':
+        label = moderatedPostLabel;
+        clickHandler = () => {
+          handleMessageRead(notif.id);
+          if (moderatedID) {
+            handleEntryClick(moderatedID);
+          }
+        };
+        break;
+      case 'MODERATED_REPLY':
+        label = moderatedReplyLabel;
+        clickHandler = () => {
+          handleMessageRead(notif.id);
+          if (moderatedID) {
+            // need to change to the reply view page later
+            handleEntryClick(moderatedID);
+          }
+        };
+        break;
+      case 'MODERATED_ACCOUNT':
+          label = moderatedAccountLabel;
+          clickHandler = () => {
+            handleMessageRead(notif.id);
+            if (moderatedID) {
+              handleProfileClick(moderatedID);
+            }
+          };
+          break;
       default:
         label = '';
         break;
@@ -220,5 +255,8 @@ NotificationsCard.defaultProps = {
   followingLabel: 'is now following you',
   repostLabel: 'reposted your post',
   markAsReadLabel: 'Mark as read',
+  moderatedPostLabel: 'moderated your post',
+  moderatedReplyLabel: 'moderated your reply',
+  moderatedAccountLabel: 'suspended your account',
 };
 export default NotificationsCard;

--- a/ui/plugins/notifications/src/components/notifications-page.tsx
+++ b/ui/plugins/notifications/src/components/notifications-page.tsx
@@ -84,6 +84,9 @@ const NotificationsPage: React.FC<RootComponentProps> = props => {
                 mentionedCommentLabel={t('mentioned you in a comment')}
                 replyLabel={t('replied to your post')}
                 repostLabel={t('reposted your post')}
+                moderatedPostLabel={t('moderated your post')}
+                moderatedReplyLabel={t('moderated your reply')}
+                moderatedAccountLabel={t('suspended your account')}
                 markAsReadLabel={t('Mark as read')}
                 emptyTitle={t('All clear')}
                 emptySubtitle={t("You don't have any new notifications!")}


### PR DESCRIPTION
This PR adds the following functionality:
* ability to send notifications to users whose content has been moderated
* switch to using pubKeys instead of ETH addresses for accounts when reporting, but also for moderators

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
