### PR TITLE
Fix/moderation pubkeys backwards compatibility

### DIFF
--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -7,7 +7,6 @@ import ProfileAPI from './profile';
 import ModerationReportAPI from './moderation-report';
 import { queryCache } from '../storage/cache';
 import { parse, stringify } from 'flatted';
-import { profile } from 'winston';
 
 /**
  * The ModerationDecisionAPI class handles all the interactions between the

--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -7,6 +7,7 @@ import ProfileAPI from './profile';
 import ModerationReportAPI from './moderation-report';
 import { queryCache } from '../storage/cache';
 import { parse, stringify } from 'flatted';
+import { profile } from 'winston';
 
 /**
  * The ModerationDecisionAPI class handles all the interactions between the
@@ -204,14 +205,16 @@ class ModerationDecisionAPI extends DataSource {
       const decision = await this.getFinalDecision(result.contentID);
       // load moderator info
       const profileAPI = new ProfileAPI({ dbID: this.dbID, collection: 'Profiles' });
-      const moderator = await profileAPI.resolveProfile(decision.moderator);
+      const moderator = decision.moderator.startsWith('0x') ? await profileAPI.getProfile(decision.moderator)
+        : await profileAPI.resolveProfile(decision.moderator);
 
       moderated.push({
         contentID: decision.contentID,
         contentType: decision.contentType,
         moderatedDate: decision.moderatedDate,
         moderator: {
-          ethAddress: moderator.ethAddress,
+          pubKey: moderator.pubKey,
+          ethAddress: moderator.ethAddress, // Deprecated, to be removed
           name: moderator.name || '',
           userName: moderator.userName || '',
           avatar: moderator.avatar,
@@ -243,10 +246,11 @@ class ModerationDecisionAPI extends DataSource {
     // add moderator data
     if (finalDecision.moderator) {
       const profileAPI = new ProfileAPI({ dbID: this.dbID, collection: 'Profiles' });
-      const moderator = await profileAPI.resolveProfile(finalDecision.moderator);
+      const moderator = finalDecision.moderator.startsWith('0x') ? await profileAPI.getProfile(finalDecision.moderator)
+        : await profileAPI.resolveProfile(finalDecision.moderator);
       finalDecision = Object.assign({}, finalDecision, { 
         moderatorProfile: {
-          ethAddress: moderator.ethAddress,
+          ethAddress: moderator.ethAddress, // Deprecated, to be removed
           pubKey: moderator.pubKey,
           name: moderator.name || "",
           userName: moderator.userName || "",


### PR DESCRIPTION
This PR adds backwards compatibility with the existing moderation data. The app currently breaks without it.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
