### PR TITLE
Feat: return basic profile data for reporters

### DIFF
--- a/api/hub/src/api.ts
+++ b/api/hub/src/api.ts
@@ -268,8 +268,7 @@ api.post('/moderation/decisions/moderate', async (ctx: koa.Context, next: () => 
         // store moderation decision
         await dataSources.decisionsAPI.makeDecision(
           report,
-          dataSources.postsAPI,
-          dataSources.profileAPI
+          dataSources.postsAPI
         );
         ctx.status = 200;
       } catch (error) {
@@ -291,7 +290,9 @@ api.get('/moderation/decisions/:contentId', async (ctx: koa.Context, next: () =>
     ctx.body = 'Missing "contentId" attribute from request.';
   } else {
     ctx.set('Content-Type', 'application/json');
-    ctx.body = await dataSources.decisionsAPI.getFinalDecision(contentID);
+    ctx.body = await dataSources.decisionsAPI.getFinalDecision(contentID,
+      dataSources.profileAPI,
+      dataSources.reportingAPI);
     ctx.status = 200;
   }
   await next();
@@ -311,7 +312,9 @@ api.post('/moderation/decisions/pending', async (ctx: koa.Context, next: () => P
   const list = [];
   for (const decision of decisions.results) {
     // get the full data for each decision
-    list.push(await dataSources.decisionsAPI.getFinalDecision(decision.contentID));
+    list.push(await dataSources.decisionsAPI.getFinalDecision(decision.contentID,
+      dataSources.profileAPI,
+      dataSources.reportingAPI));
   }
   ctx.set('Content-Type', 'application/json');
   ctx.body = {
@@ -341,7 +344,9 @@ api.post('/moderation/decisions/moderated', async (ctx: koa.Context, next: () =>
     const list = [];
     for (const decision of decisions.results) {
       // get the full data for each decision
-      list.push(await dataSources.decisionsAPI.getFinalDecision(decision.contentID));
+      list.push(await dataSources.decisionsAPI.getFinalDecision(decision.contentID,
+        dataSources.profileAPI,
+        dataSources.reportingAPI));
     }
     ctx.set('Content-Type', 'application/json');
     ctx.body = {
@@ -359,7 +364,10 @@ api.post('/moderation/decisions/moderated', async (ctx: koa.Context, next: () =>
  */
 api.post('/moderation/decisions/log', async (ctx: koa.Context, next: () => Promise<any>) => {
   const req: any = ctx?.request.body;
-  ctx.body = await dataSources.decisionsAPI.publicLog(req.offset, req.limit);
+  ctx.body = await dataSources.decisionsAPI.publicLog(dataSources.profileAPI,
+    dataSources.reportingAPI,
+    req.offset,
+    req.limit);
   ctx.set('Content-Type', 'application/json');
   ctx.status = 200;
 

--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -181,7 +181,7 @@ class ModerationDecisionAPI extends DataSource {
    * @param limit - Limit number of records returned
    * @returns A list of objects with minimal info about the moderated content
    */
-  async publicLog(offset?: number, limit?: number) {
+  async publicLog(profileAPI: ProfileAPI, reportingAPI: ModerationReportAPI, offset?: number, limit?: number) {
     let list = [];
     const db: Client = await getAppDB();
     const cachedList = this.getModeratedListCacheKey();
@@ -201,9 +201,8 @@ class ModerationDecisionAPI extends DataSource {
     const nextIndex = endIndex ? list[endIndex]._id : null;
     const moderated = [];
     for (const result of results) {
-      const decision = await this.getFinalDecision(result.contentID);
+      const decision = await this.getFinalDecision(result.contentID, profileAPI, reportingAPI);
       // load moderator info
-      const profileAPI = new ProfileAPI({ dbID: this.dbID, collection: 'Profiles' });
       const moderator = decision.moderator.startsWith('0x') ? await profileAPI.getProfile(decision.moderator)
         : await profileAPI.resolveProfile(decision.moderator);
 
@@ -231,10 +230,11 @@ class ModerationDecisionAPI extends DataSource {
   /**
    * Aggregates data for a final decision. It contains profile data for moderator,
    * first report, number of total reports, and full list of reasons it was reported for.
-   * @param contentID The content identifier
+   * @param contentID - The content identifier
+   * @param profileAPI - The profile data source API
    * @returns An object with all the relevant data
    */
-  async getFinalDecision(contentID: string) {
+  async getFinalDecision(contentID: string, profileAPI: ProfileAPI, reportingAPI: ModerationReportAPI) {
     const decisionCache = this.getModeratedDecisionCacheKey(contentID);
     if (await queryCache.has(decisionCache)) {
       return queryCache.get(decisionCache);
@@ -244,7 +244,6 @@ class ModerationDecisionAPI extends DataSource {
     let { actions, ...finalDecision } = decision;
     // add moderator data
     if (finalDecision.moderator) {
-      const profileAPI = new ProfileAPI({ dbID: this.dbID, collection: 'Profiles' });
       const moderator = finalDecision.moderator.startsWith('0x') ? await profileAPI.getProfile(finalDecision.moderator)
         : await profileAPI.resolveProfile(finalDecision.moderator);
       finalDecision = Object.assign({}, finalDecision, { 
@@ -253,17 +252,15 @@ class ModerationDecisionAPI extends DataSource {
           pubKey: moderator.pubKey,
           name: moderator.name || "",
           userName: moderator.userName || "",
-          avatar: moderator.avatar,
+          avatar: moderator.avatar || "",
         }
       });
     }
     // add first report data
-    const reportingAPI = new ModerationReportAPI({
-      dbID: this.dbID,
-      collection: 'ModerationReports',
-    });
     const first = await reportingAPI.getFirstReport(contentID);
-    const reportedBy = first.author;
+    first.author 
+    const reportedBy = { 
+    };
     const reportedDate = first.creationDate;
     // count reports
     const reports = await reportingAPI.countReports(contentID);
@@ -276,13 +273,12 @@ class ModerationDecisionAPI extends DataSource {
 
   /**
    * Moderate content by making a formal decision.
-   * @param contentID - The content identifier
-   * @param moderator - The moderator user who made the final decision
-   * @param explanation - Personal conclusion of the moderator
+   * @param report - The object containing relevant data for the report
+   * @param postsAPI - The posts data source API
    * @param delisted - Outcome of the moderation action (delisted or kept)
    * @reurns The ModerationDecision object
    */
-  async makeDecision(report: any, postsAPI: PostsAPI, profileAPI: ProfileAPI) {
+  async makeDecision(report: any, postsAPI: PostsAPI) {
     const db: Client = await getAppDB();
     if (!report.data.moderator) {
       throw new Error('Not authorized');

--- a/api/hub/src/datasources/moderation-decision.ts
+++ b/api/hub/src/datasources/moderation-decision.ts
@@ -258,15 +258,22 @@ class ModerationDecisionAPI extends DataSource {
     }
     // add first report data
     const first = await reportingAPI.getFirstReport(contentID);
-    first.author 
-    const reportedBy = { 
-    };
+    const reportedBy = first.author;
     const reportedDate = first.creationDate;
+    const author = await first.author.startsWith('0x') ? await profileAPI.getProfile(first.author)
+    : await profileAPI.resolveProfile(first.author);
+    const reportedByProfile = {
+      ethAddress: author.ethAddress, // Deprecated, to be removed
+      pubKey: author.pubKey,
+      name: author.name || "",
+      userName: author.userName || "",
+      avatar: author.avatar || "",
+    };
     // count reports
     const reports = await reportingAPI.countReports(contentID);
     // add reasons
     const reasons = await reportingAPI.getReasons(contentID);
-    finalDecision = Object.assign({}, finalDecision, { reports, reportedBy, reportedDate, reasons });
+    finalDecision = Object.assign({}, finalDecision, { reports, reportedBy, reportedDate, reportedByProfile, reasons });
     await queryCache.set(decisionCache, finalDecision);
     return finalDecision;
   }


### PR DESCRIPTION
This PR adds some basic profile data to the list of pending requests, to avoid having to perform additional requests in the client.

It also removes the need to initialize external APIs, by passing the instanced object instead. 

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
