### PR TITLE
Resolve ETH addr to pubKey for new moderators

### DIFF
--- a/api/hub/src/api.ts
+++ b/api/hub/src/api.ts
@@ -403,6 +403,7 @@ api.post('/moderation/moderators/new', async (ctx: koa.Context, next: () => Prom
           request.data.user,
           request.data.admin,
           request.data.active,
+          dataSources.profileAPI,
         );
         ctx.status = 201;
       }
@@ -432,6 +433,7 @@ api.post('/moderation/moderators/:user', async (ctx: koa.Context, next: () => Pr
           user,
           request.data.admin,
           request.data.active,
+          dataSources.profileAPI,
         );
         ctx.status = 200;
       }

--- a/api/hub/src/datasources/moderation-admin.ts
+++ b/api/hub/src/datasources/moderation-admin.ts
@@ -3,6 +3,7 @@ import { getAppDB, logger } from '../helpers';
 import { Client, ThreadID } from '@textile/hub';
 import { Moderator } from '../collections/interfaces';
 import { queryCache } from '../storage/cache';
+import { ethers } from 'ethers';
 import ProfileAPI from './profile';
 
 /**
@@ -81,7 +82,7 @@ class ModerationAdminAPI extends DataSource {
    */
   async updateModerator(user: string, admin: boolean, active: boolean, profileAPI: ProfileAPI) {
     // resolve ETH address to pubKey if needed
-    if (user.startsWith('0x')) {
+    if (ethers.utils.isAddress(user)) {
       const moderator = await profileAPI.getProfile(user);
       if (moderator) {
         user = moderator.pubKey;

--- a/api/hub/src/datasources/moderation-admin.ts
+++ b/api/hub/src/datasources/moderation-admin.ts
@@ -3,6 +3,7 @@ import { getAppDB, logger } from '../helpers';
 import { Client, ThreadID } from '@textile/hub';
 import { Moderator } from '../collections/interfaces';
 import { queryCache } from '../storage/cache';
+import ProfileAPI from './profile';
 
 /**
  * The ModerationAdminAPI class handles all the interactions between the admin
@@ -78,7 +79,14 @@ class ModerationAdminAPI extends DataSource {
    * @param admin - A boolean flag for the admin status
    * @param active - A boolean flag for the active status
    */
-  async updateModerator(user: string, admin: boolean, active: boolean) {
+  async updateModerator(user: string, admin: boolean, active: boolean, profileAPI: ProfileAPI) {
+    // resolve ETH address to pubKey if needed
+    if (user.startsWith('0x')) {
+      const moderator = await profileAPI.getProfile(user);
+      if (moderator) {
+        user = moderator.pubKey;
+      }
+    }
     const moderatorCacheKey = this.getModeratorCacheKey(user);
     const db: Client = await getAppDB();
     // check if moderator already exists


### PR DESCRIPTION
When adding moderators, requests can now specify ETH addresses that will be resolved to pubKeys before storing the data.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
