### PR TITLE
apply `flex-direction` to widget slots

### DIFF
--- a/ui/widgets/layout/src/components/styled-slots.ts
+++ b/ui/widgets/layout/src/components/styled-slots.ts
@@ -53,6 +53,7 @@ export const WidgetSlot: React.FC<ExtensionPointProps> = styled(BaseStyledSlot)`
     @media screen and (min-width: ${props.theme.breakpoints.small.value}px) {
       max-width: 30em;
       display: flex;
+      flex-direction: column;
     }
 
     @media screen and (min-width: ${props.theme.breakpoints.medium.value}px) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixes an issue in entry-page where the profile widget would be hidden because it's outside of the widget area

<!--- Describe your changes in detail -->

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
