### PR TITLE
feat(feed): tooltip on timestamp

### DIFF
--- a/ui/design/src/components/EntryCard/entry-box.tsx
+++ b/ui/design/src/components/EntryCard/entry-box.tsx
@@ -18,7 +18,7 @@ import EmbedBox from '../EmbedBox';
 import ReadOnlyEditor from '../ReadOnlyEditor';
 import ViewportSizeProvider from '../Providers/viewport-dimension';
 
-import { formatRelativeTime, ILocale } from '../../utils/time';
+import { formatDate, formatRelativeTime, ILocale } from '../../utils/time';
 import { IEntryData, EntityTypes, NavigateToParams } from '@akashaorg/typings/ui';
 import LinkPreview from '../Editor/link-preview';
 import Tooltip from '../Tooltip';
@@ -379,9 +379,16 @@ const EntryBox: React.FC<IEntryBoxProps> = props => {
           )}
           <Box direction="row" gap="xsmall" align="center" flex={{ shrink: 0 }}>
             {entryData.time && !hidePublishTime && (
-              <Text style={{ flexShrink: 0 }} color="secondaryText">
-                {formatRelativeTime(entryData.time, locale)}
-              </Text>
+              <Tooltip
+                dropProps={{ align: { top: 'bottom' } }}
+                message={formatDate(entryData.time, locale)}
+                plain={true}
+                caretPosition={'top'}
+              >
+                <Text style={{ flexShrink: 0 }} color="secondaryText">
+                  {formatRelativeTime(entryData.time, locale)}
+                </Text>
+              </Tooltip>
             )}
             {!!entryData?.updatedAt && (
               <Tooltip


### PR DESCRIPTION
Added a tooltip to the timestamp that will show the formatted time of posting

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
