### PR TITLE
feat(ui): card-actions repost button changes

### DIFF
--- a/ui/design/src/components/EntryCard/__tests__/index.test.tsx
+++ b/ui/design/src/components/EntryCard/__tests__/index.test.tsx
@@ -70,7 +70,7 @@ describe('<EntryCard /> Component', () => {
 
   it('triggers the handlers on the action buttons', async () => {
     const { getByText } = componentWrapper;
-    const repostButton = getByText(/11 Reposts/i);
+    const repostButton = getByText('11');
     expect(repostButton).toBeDefined();
 
     expect(handleRepost).toBeCalledTimes(0);

--- a/ui/design/src/components/EntryCard/card-actions.tsx
+++ b/ui/design/src/components/EntryCard/card-actions.tsx
@@ -24,7 +24,6 @@ export interface CardActionProps {
   shareTextLabel?: string;
   sharePostUrl?: string;
   // labels
-  repostsLabel: string;
   repostLabel?: string;
   cancelLabel?: string;
   repostWithCommentLabel?: string;
@@ -54,7 +53,6 @@ const CardActions: React.FC<CardActionProps> = props => {
     shareTextLabel,
     sharePostUrl,
     // labels
-    repostsLabel,
     repostLabel,
     cancelLabel,
     repostWithCommentLabel,
@@ -250,9 +248,7 @@ const CardActions: React.FC<CardActionProps> = props => {
     );
   };
 
-  const repostsBtnText = isMobile
-    ? `${entryData.reposts || 0}`
-    : `${entryData.reposts || 0} ${repostsLabel}`;
+  const repostsBtnText = `${entryData.reposts || ''}`;
   const repliesBtnText = isMobile
     ? `${entryData.replies || 0}`
     : `${entryData.replies || 0} ${repliesLabel}`;
@@ -269,6 +265,15 @@ const CardActions: React.FC<CardActionProps> = props => {
         justify="between"
       >
         <TextIcon
+          label={repliesBtnText}
+          iconType="comments"
+          iconSize="sm"
+          fontSize="large"
+          clickable={disableReposting ? false : true}
+          onClick={disableReposting ? () => false : handleRepliesClick}
+          disabled={disableReposting}
+        />
+        <TextIcon
           label={repostsBtnText}
           iconType="transfer"
           iconSize="sm"
@@ -278,15 +283,6 @@ const CardActions: React.FC<CardActionProps> = props => {
           onClick={disableReposting ? () => false : onRepost}
           disabled={disableReposting}
         />
-        <TextIcon
-          label={repliesBtnText}
-          iconType="comments"
-          iconSize="sm"
-          fontSize="large"
-          clickable={disableReposting ? false : true}
-          onClick={disableReposting ? () => false : handleRepliesClick}
-          disabled={disableReposting}
-        />
       </Box>
     );
   }
@@ -294,21 +290,6 @@ const CardActions: React.FC<CardActionProps> = props => {
   return (
     <Box pad="medium" direction="row" justify="between">
       {repostNodeRef.current && repostDropOpen && renderRepostDrop()}
-      <TextIcon
-        label={repostsBtnText}
-        iconType="transfer"
-        iconSize="sm"
-        fontSize="large"
-        clickable={!disableReposting && !disableActions}
-        ref={repostNodeRef}
-        onClick={() => {
-          if (disableActions || disableReposting) {
-            return;
-          }
-          onRepost();
-        }}
-        disabled={disableReposting || disableActions}
-      />
       <Anchor
         onClick={e => {
           e.preventDefault();
@@ -333,6 +314,21 @@ const CardActions: React.FC<CardActionProps> = props => {
             disabled={disableActions}
           />
         }
+      />
+      <TextIcon
+        label={repostsBtnText}
+        iconType="transfer"
+        iconSize="sm"
+        fontSize="large"
+        clickable={!disableReposting && !disableActions}
+        ref={repostNodeRef}
+        onClick={() => {
+          if (disableActions || disableReposting) {
+            return;
+          }
+          onRepost();
+        }}
+        disabled={disableReposting || disableActions}
       />
       {actionsRightExt}
       {shareNodeRef.current && shareDropOpen && renderShareDrop()}

--- a/ui/design/src/components/EntryCard/entry-box.tsx
+++ b/ui/design/src/components/EntryCard/entry-box.tsx
@@ -566,7 +566,6 @@ const EntryBox: React.FC<IEntryBoxProps> = props => {
             shareTextLabel={shareTextLabel}
             sharePostUrl={sharePostUrl}
             repliesLabel={repliesLabel}
-            repostsLabel={repostsLabel}
             repostLabel={repostLabel}
             cancelLabel={cancelLabel}
             repostWithCommentLabel={repostWithCommentLabel}


### PR DESCRIPTION
figma design:
https://www.figma.com/file/fay7vbao49vi2LYYNvhQ7E/%5BDesign%5D-Replies?node-id=31%3A54680

The repost button no longer has copy, and it changed places with the replies button.

Checklist

- [x] I have read the README document
- [x] I have read the CONTRIBUTING document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
