### PR TITLE
Fix: move selection at the end when editor mounts

### DIFF
--- a/ui/design/src/components/Editor/index.tsx
+++ b/ui/design/src/components/Editor/index.tsx
@@ -223,8 +223,8 @@ const EditorBox: React.FC<IEditorBox> = React.forwardRef((props, ref) => {
    * set the selection at the end of the content when component is mounted
    */
   useEffect(() => {
-    Transforms.move(editorRef.current);
-  }, []);
+    Transforms.select(editor, Editor.end(editor, []));
+  }, [editor]);
 
   /**
    * position the mention and tag popovers based on the matching text range


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Move selection at the end when editor mounts

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
