### PR TITLE
Fix: pending entry ui should disappear immediately after the entry appears on a feed

### DIFF
--- a/ui/apps/akasha/src/components/feed-page/feed-page.tsx
+++ b/ui/apps/akasha/src/components/feed-page/feed-page.tsx
@@ -147,7 +147,10 @@ const FeedPage: React.FC<FeedPageProps & RootComponentProps> = props => {
       )}
       {pendingPostStates?.map(
         pendingPostState =>
-          pendingPostState.state.status === 'loading' && (
+          (pendingPostState.state.status === 'loading' ||
+            /*The following line ensures that even if the post is published pending post UI should be shown till the new entry appears on the feed */
+            (pendingPostState.state.status === 'success' &&
+              !postPages[0]?.results.includes(pendingPostState.state.data.toString()))) && (
             <EntryCard
               key={pendingPostState.mutationId}
               style={{ backgroundColor: '#4e71ff0f', marginBottom: '0.5rem' }}

--- a/ui/apps/akasha/src/components/post-page/common/base-entry-page.tsx
+++ b/ui/apps/akasha/src/components/post-page/common/base-entry-page.tsx
@@ -151,6 +151,7 @@ const BaseEntryPage: React.FC<BaseEntryProps & RootComponentProps> = props => {
             layoutConfig={props.layoutConfig}
             loggedProfileData={loggedProfileData}
             entryData={entryData}
+            commentIds={commentPages ? commentPages[0].results : []}
           />
           <FeedWidget
             modalSlotId={props.layoutConfig.modalSlotId}

--- a/ui/apps/akasha/src/components/post-page/common/pending-reply.tsx
+++ b/ui/apps/akasha/src/components/post-page/common/pending-reply.tsx
@@ -20,10 +20,17 @@ type Props = {
   /* @Todo: Fix my type */
   loggedProfileData: any;
   layoutConfig: RootComponentProps['layoutConfig'];
+  commentIds: string[];
   entryData?: IEntryData;
 };
 
-export function PendingReply({ postId, layoutConfig, loggedProfileData, entryData }: Props) {
+export function PendingReply({
+  postId,
+  layoutConfig,
+  loggedProfileData,
+  commentIds,
+  entryData,
+}: Props) {
   const { t } = useTranslation('app-akasha-integration');
   const { mutations: pendingReplyStates } = useMutationsListener<IPublishData & { postID: string }>(
     PUBLISH_PENDING_KEY,
@@ -53,7 +60,10 @@ export function PendingReply({ postId, layoutConfig, loggedProfileData, entryDat
       {pendingReplyStates?.map(
         pendingReplyState =>
           pendingReplyState &&
-          pendingReplyState.state.status === 'loading' &&
+          (pendingReplyState.state.status === 'loading' ||
+            /*The following line ensures that even if the reply is published pending reply UI should be shown till the new entry appears in the feed */
+            (pendingReplyState.state.status === 'success' &&
+              !commentIds.includes(pendingReplyState.state.data.toString()))) &&
           pendingReplyState.state.variables.postID === postId && (
             <Box
               pad={{ horizontal: 'medium' }}

--- a/ui/hooks/src/use-comments.ts
+++ b/ui/hooks/src/use-comments.ts
@@ -297,8 +297,9 @@ export function useCreateComment() {
           }
         });
       },
-      onSettled: async () => {
-        await queryClient.invalidateQueries(COMMENTS_KEY);
+      onSettled: () => {
+        //shouldn't await 'COMMENTS_KEY' as it creates a race condition
+        queryClient.invalidateQueries(COMMENTS_KEY);
       },
       mutationKey: PUBLISH_PENDING_KEY,
     },

--- a/ui/hooks/src/use-posts.ts
+++ b/ui/hooks/src/use-posts.ts
@@ -430,7 +430,8 @@ export function useCreatePost() {
         await queryClient.fetchQuery([ENTRY_KEY, id], () => getPost(id));
       },
       onSettled: async () => {
-        await queryClient.invalidateQueries(ENTRIES_KEY);
+        //shouldn't await 'ENTRIES_KEY' as as it creates a race condition
+        queryClient.invalidateQueries(ENTRIES_KEY);
         await queryClient.invalidateQueries(TRENDING_TAGS_KEY);
       },
       mutationKey: CREATE_POST_MUTATION_KEY,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Pending entry ui should disappear immediately after the entry appears on a feed

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
