### PR TITLE
fix: prevent scroll top button from showing on page load

### DIFF
--- a/ui/design/src/components/EntryList/index.tsx
+++ b/ui/design/src/components/EntryList/index.tsx
@@ -57,7 +57,8 @@ const EntryList = (props: EntryListProps) => {
     const observer = elementIntersectionObserver({
       element: startScrollRef?.current,
       onIntersect: () => {
-        setHideScrollTop(false);
+        //scrollY check prevents the scroll top button from showing on page load
+        if (window.scrollY > 0) setHideScrollTop(false);
       },
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Prevent scroll top button from showing on page load

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
