### PR TITLE
change single-spa-react options

### DIFF
--- a/ui/apps/akasha-verse/package.json
+++ b/ui/apps/akasha-verse/package.json
@@ -50,8 +50,7 @@
     "@types/react-dom": "18.0.11",
     "@types/react-router": "5.1.18",
     "@types/react-router-dom": "5.3.3",
-    "@types/react-test-renderer": "17.0.1",
-    "@types/single-spa-react": "3.0.1"
+    "@types/react-test-renderer": "17.0.1"
   },
   "peerDependencies": {
     "react": "^18.1.0",

--- a/ui/apps/akasha-verse/src/components/index.tsx
+++ b/ui/apps/akasha-verse/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './App';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/akasha-verse/src/extensions/install-app.tsx
+++ b/ui/apps/akasha-verse/src/extensions/install-app.tsx
@@ -101,9 +101,8 @@ const ModalWrapper: React.FC<RootExtensionProps> = props => {
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(ModalWrapper),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`Error in InstallModal: ${JSON.stringify(err)}, ${errorInfo}`);

--- a/ui/apps/akasha/src/components/index.tsx
+++ b/ui/apps/akasha/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './app';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/akasha/src/extensions/entry-edit-button.tsx
+++ b/ui/apps/akasha/src/extensions/entry-edit-button.tsx
@@ -53,9 +53,8 @@ const ModalWrapper: React.FC<RootExtensionProps> = props => {
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(ModalWrapper),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(errorInfo)}, ${errorInfo}`);

--- a/ui/apps/akasha/src/extensions/entry-remove-modal.tsx
+++ b/ui/apps/akasha/src/extensions/entry-remove-modal.tsx
@@ -98,9 +98,8 @@ const ModalWrapper: React.FC<RootExtensionProps> = props => {
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(ModalWrapper),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(err)}, ${errorInfo}`);

--- a/ui/apps/akasha/src/extensions/inline-editor/index.tsx
+++ b/ui/apps/akasha/src/extensions/inline-editor/index.tsx
@@ -18,9 +18,8 @@ const Wrapped = (props: RootExtensionProps) => {
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Wrapped),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(errorInfo)}, ${errorInfo}`);

--- a/ui/apps/articles/package.json
+++ b/ui/apps/articles/package.json
@@ -51,8 +51,7 @@
     "@types/react-dom": "18.0.11",
     "@types/react-router": "5.1.18",
     "@types/react-router-dom": "5.3.3",
-    "@types/react-test-renderer": "17.0.1",
-    "@types/single-spa-react": "3.0.1"
+    "@types/react-test-renderer": "17.0.1"
   },
   "peerDependencies": {
     "react": "^18.1.0",

--- a/ui/apps/articles/src/components/index.tsx
+++ b/ui/apps/articles/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './app';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/articles/src/extensions/manage-collaborators-modal.tsx
+++ b/ui/apps/articles/src/extensions/manage-collaborators-modal.tsx
@@ -98,9 +98,8 @@ const Wrapped = (props: RootExtensionProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Wrapped),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(err)}, ${errorInfo}`);

--- a/ui/apps/auth-app/src/components/index.tsx
+++ b/ui/apps/auth-app/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './app';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/bookmarks/package.json
+++ b/ui/apps/bookmarks/package.json
@@ -51,8 +51,7 @@
     "@types/react-dom": "18.0.11",
     "@types/react-router": "5.1.18",
     "@types/react-router-dom": "5.3.3",
-    "@types/react-test-renderer": "17.0.1",
-    "@types/single-spa-react": "3.0.1"
+    "@types/react-test-renderer": "17.0.1"
   },
   "peerDependencies": {
     "react": "^18.1.0",

--- a/ui/apps/bookmarks/src/components/index.tsx
+++ b/ui/apps/bookmarks/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './App';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/bookmarks/src/extensions/entry-card-save-button.tsx
+++ b/ui/apps/bookmarks/src/extensions/entry-card-save-button.tsx
@@ -73,9 +73,8 @@ const BookmarkButtonWrapper = (props: RootExtensionProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(BookmarkButtonWrapper),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(errorInfo)}, ${errorInfo}`);

--- a/ui/apps/dev-dashboard/package.json
+++ b/ui/apps/dev-dashboard/package.json
@@ -51,8 +51,7 @@
     "@types/react-dom": "18.0.11",
     "@types/react-router": "5.1.18",
     "@types/react-router-dom": "5.3.3",
-    "@types/react-test-renderer": "17.0.1",
-    "@types/single-spa-react": "3.0.1"
+    "@types/react-test-renderer": "17.0.1"
   },
   "peerDependencies": {
     "react": "^18.1.0",

--- a/ui/apps/dev-dashboard/src/components/index.tsx
+++ b/ui/apps/dev-dashboard/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './App';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/dev-dashboard/src/extensions/delete-dev-key.tsx
+++ b/ui/apps/dev-dashboard/src/extensions/delete-dev-key.tsx
@@ -101,9 +101,8 @@ const Wrapped = (props: RootExtensionProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Wrapped),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(err)}, ${errorInfo}`);

--- a/ui/apps/legal/src/components/index.tsx
+++ b/ui/apps/legal/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './App';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/messaging/package.json
+++ b/ui/apps/messaging/package.json
@@ -52,8 +52,7 @@
     "@akashaorg/typings": "*",
     "@types/react": "18.0.33",
     "@types/react-dom": "18.0.11",
-    "@types/react-test-renderer": "17.0.1",
-    "@types/single-spa-react": "3.0.1"
+    "@types/react-test-renderer": "17.0.1"
   },
   "peerDependencies": {
     "react": "^18.0.1",

--- a/ui/apps/messaging/src/components/index.tsx
+++ b/ui/apps/messaging/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './App';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/messaging/src/extensions/mini-profile-message-button.tsx
+++ b/ui/apps/messaging/src/extensions/mini-profile-message-button.tsx
@@ -79,9 +79,8 @@ const MessageButtonWrapper = (props: RootExtensionProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(MessageButtonWrapper),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(errorInfo)}, ${errorInfo}`);

--- a/ui/apps/messaging/src/extensions/profile-message-button.tsx
+++ b/ui/apps/messaging/src/extensions/profile-message-button.tsx
@@ -68,9 +68,8 @@ const MessageIconButtonWrapper = (props: RootExtensionProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(MessageIconButtonWrapper),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(errorInfo)}, ${errorInfo}`);

--- a/ui/apps/moderation/src/components/index.tsx
+++ b/ui/apps/moderation/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './app';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/notifications/src/components/index.tsx
+++ b/ui/apps/notifications/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './app';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/profile/src/components/index.tsx
+++ b/ui/apps/profile/src/components/index.tsx
@@ -9,9 +9,8 @@ import App from './App';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/profile/src/extensions/login-modal.tsx
+++ b/ui/apps/profile/src/extensions/login-modal.tsx
@@ -73,9 +73,8 @@ const Wrapped = (props: RootExtensionProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Wrapped),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(err)}, ${errorInfo}`);

--- a/ui/apps/profile/src/extensions/share-profile-modal.tsx
+++ b/ui/apps/profile/src/extensions/share-profile-modal.tsx
@@ -49,9 +49,8 @@ const ShareProfileModal: React.FC<RootExtensionProps> = props => {
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(ShareProfileModal),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/search/src/components/index.tsx
+++ b/ui/apps/search/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './App';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/apps/settings-app/src/components/index.tsx
+++ b/ui/apps/settings-app/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './app';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/lib/feed/src/components/index.tsx
+++ b/ui/lib/feed/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './App';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/widgets/analytics/src/components/index.tsx
+++ b/ui/widgets/analytics/src/components/index.tsx
@@ -7,9 +7,8 @@ import CookieWidget from './cookie-widget';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(CookieWidget),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(err)}, ${errorInfo}`);

--- a/ui/widgets/layout/src/components/index.tsx
+++ b/ui/widgets/layout/src/components/index.tsx
@@ -18,9 +18,8 @@ import LayoutWidget from './layout-widget';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(LayoutWidget),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/widgets/mini-profile/src/MiniProfileWidget.tsx
+++ b/ui/widgets/mini-profile/src/MiniProfileWidget.tsx
@@ -186,9 +186,8 @@ const Wrapped = (props: RootExtensionProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Wrapped),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(errorInfo)}, ${errorInfo}`);

--- a/ui/widgets/my-apps/src/my-apps-widget.tsx
+++ b/ui/widgets/my-apps/src/my-apps-widget.tsx
@@ -133,9 +133,8 @@ const Wrapped = (props: RootComponentProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Wrapped),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(errorInfo)}, ${errorInfo}`);

--- a/ui/widgets/sidebar/src/components/index.tsx
+++ b/ui/widgets/sidebar/src/components/index.tsx
@@ -10,9 +10,8 @@ import Widget from './sidebar-widget';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Widget),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/widgets/top-bar/src/components/index.tsx
+++ b/ui/widgets/top-bar/src/components/index.tsx
@@ -10,9 +10,8 @@ import Widget from './topbar-widget';
 
 const reactLifecycles = singleSpaReact<RootComponentProps>({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Widget),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/ui/widgets/top-bar/src/extensions/feedback-modal.tsx
+++ b/ui/widgets/top-bar/src/extensions/feedback-modal.tsx
@@ -46,9 +46,8 @@ const Wrapped = (props: RootExtensionProps) => (
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(Wrapped),
-  renderType: 'createRoot',
   errorBoundary: (err, errorInfo, props: RootExtensionProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(err)}, ${errorInfo}`);

--- a/ui/widgets/trending/src/components/index.tsx
+++ b/ui/widgets/trending/src/components/index.tsx
@@ -10,9 +10,8 @@ import App from './app';
 
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
+  ReactDOMClient: ReactDOM,
   rootComponent: withProviders(App),
-  renderType: 'createRoot',
   errorBoundary: (error, errorInfo, props: RootComponentProps) => {
     if (props.logger) {
       props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7602,14 +7602,6 @@
     "@types/mime" "*"
     "@types/node" "*"
 
-"@types/single-spa-react@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/single-spa-react/-/single-spa-react-3.0.1.tgz#c5da7d1db373213d57c3497c7f6994145a929f86"
-  integrity sha512-fneozhJ0k0v3a4eGtQww0ks7ytUQLaUh43iV6x6oudA3YdKIIIgMPoVm9oC7ZInoe7H5/fozom0iFXy98XC+tg==
-  dependencies:
-    "@types/react" "*"
-    "@types/react-dom" "*"
-
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- remove @types/single-spa-react package
- change ReactDOM to ReactDOMClient
- remove `renderType: 'createRoot'` because it's now default option when using `ReactDOMClient` property

<!--- Describe your changes in detail -->

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
