### PR TITLE
fix(profile-app): reset to last saved image when closing image modal

### DIFF
--- a/ui/design-system-components/src/components/EditProfile/General/Header/index.tsx
+++ b/ui/design-system-components/src/components/EditProfile/General/Header/index.tsx
@@ -69,6 +69,8 @@ export const Header: React.FC<HeaderProps> = ({
   const [showDeleteImage, setShowDeleteImage] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(transformSource(avatar?.default));
   const [coverImageUrl, setCoverImageUrl] = useState(transformSource(coverImage?.default));
+  const [lastAvatarUrl, setLastAvatarUrl] = useState(transformSource(avatar?.default));
+  const [lastCoverImageUrl, setLastCoverImageUrl] = useState(transformSource(coverImage?.default));
   const alternativeAvatars = useRef(
     avatar?.alternatives?.map(alternative => transformSource(alternative)),
   );
@@ -140,11 +142,13 @@ export const Header: React.FC<HeaderProps> = ({
         case 'avatar':
           onImageSave('avatar', image);
           onAvatarChange(image);
+          setLastAvatarUrl(avatarUrl);
           setAvatarUrl({ src: URL.createObjectURL(image), width: 0, height: 0 });
           break;
         case 'cover-image':
           onImageSave('cover-image', image);
           onCoverImageChange(image);
+          setLastCoverImageUrl(coverImageUrl);
           setCoverImageUrl({ src: URL.createObjectURL(image), width: 0, height: 0 });
       }
     }
@@ -262,7 +266,16 @@ export const Header: React.FC<HeaderProps> = ({
         title={profileImageType === 'avatar' ? imageTitle.avatar : imageTitle.coverImage}
         cancelLabel={cancelLabel}
         saveLabel={saveLabel}
-        onClose={() => (isSavingImage ? undefined : setShowEditImage(false))}
+        onClose={() => {
+          if (isSavingImage) return;
+          if (profileImageType === 'avatar') {
+            setAvatarUrl(lastAvatarUrl);
+          }
+          if (profileImageType === 'cover-image') {
+            setCoverImageUrl(lastCoverImageUrl);
+          }
+          setShowEditImage(false);
+        }}
         images={profileImageType === 'avatar' ? [avatarUrl?.src] : [coverImageUrl?.src]}
         dragToRepositionLabel={dragToRepositionLabel}
         isSavingImage={isSavingImage}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- reset to last saved image when closing image modal

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
