### PR TITLE
feat(): extract profile info in beam card to an extension

### DIFF
--- a/tests/src/data-generator/store.ts
+++ b/tests/src/data-generator/store.ts
@@ -9,9 +9,6 @@ export function getUserInfo(): IUserState<AkashaProfile> {
     authenticationError: null,
     authenticatedProfileError: null,
     isAuthenticating: false,
-    info: {},
-    isLoadingInfo: false,
-    infoError: null,
   };
 }
 
@@ -44,7 +41,6 @@ export function getUserStore(initialState: IUserState<AkashaProfile>): IUserStor
     logout: () => {
       setState(getUserInfo());
     },
-    getUserInfo: () => jest.fn(),
     restoreSession: () => {
       setState({ ...state, isAuthenticating: true });
       setTimeout(

--- a/typings/src/ui/store.ts
+++ b/typings/src/ui/store.ts
@@ -18,10 +18,6 @@ export interface IUserState<T> {
   authenticatedProfileError: Error;
   authenticationError: Error;
   isAuthenticating: boolean;
-  //User profile info
-  info: Record<string, T>;
-  isLoadingInfo: boolean;
-  infoError: Error;
 }
 
 /**
@@ -39,7 +35,6 @@ export interface IGetProfileInfo<T> {
 export interface IUserStore<T> {
   login({ provider, checkRegistered }: Login): void;
   logout(): void;
-  getUserInfo({ profileDID }: GetUserInfo): void;
   restoreSession(): void;
   subscribe(listener: () => void): () => void;
   getSnapshot(): IUserState<T>;

--- a/ui/apps/auth-app/src/components/pages/main-page.tsx
+++ b/ui/apps/auth-app/src/components/pages/main-page.tsx
@@ -7,7 +7,7 @@ const MainPage: React.FC = () => {
   const { worldConfig, getRoutingPlugin } = useRootComponentProps();
 
   const {
-    data: { authenticatedDID, isLoadingInfo, authenticatedProfile },
+    data: { authenticatedDID, authenticatedProfile },
   } = useAkashaStore();
   const isLoggedIn = !!authenticatedDID;
 
@@ -16,7 +16,7 @@ const MainPage: React.FC = () => {
     const searchParam = new URLSearchParams(location.search);
 
     // if user is logged in, do not show the connect page
-    if (isLoggedIn && !isLoadingInfo) {
+    if (isLoggedIn) {
       if (!authenticatedProfile) {
         routingPlugin.current?.navigateTo({
           appName: '@akashaorg/app-profile',
@@ -31,7 +31,7 @@ const MainPage: React.FC = () => {
         },
       });
     }
-  }, [isLoggedIn, authenticatedDID, worldConfig.homepageApp, isLoadingInfo, authenticatedProfile]);
+  }, [isLoggedIn, authenticatedDID, worldConfig.homepageApp, authenticatedProfile]);
   return (
     <Card padding="px-4 py-6">
       <Outlet />

--- a/ui/apps/profile/src/extensions/follow-profile-button.tsx
+++ b/ui/apps/profile/src/extensions/follow-profile-button.tsx
@@ -14,7 +14,7 @@ type FollowProfileButtonExtensionData = {
   followId: string;
 };
 
-const App = (props: RootExtensionProps<FollowProfileButtonExtensionData>) => {
+const Index = (props: RootExtensionProps<FollowProfileButtonExtensionData>) => {
   const { navigateToModal, extensionData } = props;
   const { profileID, isLoggedIn, isFollowing, followId } = extensionData;
   const { getTranslationPlugin } = useRootComponentProps();
@@ -41,7 +41,7 @@ const App = (props: RootExtensionProps<FollowProfileButtonExtensionData>) => {
 const reactLifecycles = singleSpaReact({
   React,
   ReactDOMClient,
-  rootComponent: withProviders(App),
+  rootComponent: withProviders(Index),
   errorBoundary: (
     error,
     errorInfo,

--- a/ui/apps/profile/src/extensions/profile-avatar/index.tsx
+++ b/ui/apps/profile/src/extensions/profile-avatar/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import ReactDOMClient from 'react-dom/client';
+import ErrorLoader from '@akashaorg/design-system-core/lib/components/ErrorLoader';
+import singleSpaReact from 'single-spa-react';
+import ProfileAvatar, { ProfileAvatarProps } from './profile-avatar';
+import { useRootComponentProps, withProviders } from '@akashaorg/ui-awf-hooks';
+import { RootExtensionProps } from '@akashaorg/typings/lib/ui';
+import { I18nextProvider } from 'react-i18next';
+
+const Index = (props: RootExtensionProps<ProfileAvatarProps>) => {
+  const { extensionData } = props;
+  const { getTranslationPlugin } = useRootComponentProps();
+
+  return (
+    <I18nextProvider i18n={getTranslationPlugin().i18n}>
+      <ProfileAvatar {...extensionData} />
+    </I18nextProvider>
+  );
+};
+
+const reactLifecycles = singleSpaReact({
+  React,
+  ReactDOMClient,
+  rootComponent: withProviders(Index),
+  errorBoundary: (error, errorInfo, props: RootExtensionProps<ProfileAvatarProps>) => {
+    if (props.logger) {
+      props.logger.error(`${JSON.stringify(error)}, ${errorInfo}`);
+    }
+    return (
+      <ErrorLoader type="script-error" title="Error in profile avatar" details={error.message} />
+    );
+  },
+});
+
+export const bootstrap = reactLifecycles.bootstrap;
+
+export const mount = reactLifecycles.mount;
+
+export const unmount = reactLifecycles.unmount;

--- a/ui/apps/profile/src/extensions/profile-avatar/profile-avatar.tsx
+++ b/ui/apps/profile/src/extensions/profile-avatar/profile-avatar.tsx
@@ -1,0 +1,45 @@
+import React, { ReactElement } from 'react';
+import ProfileAvatarButton from '@akashaorg/design-system-core/lib/components/ProfileAvatarButton';
+import ProfileAvatarLoading from '@akashaorg/design-system-core/lib/components/ProfileAvatarButton/ProfileAvatarLoading';
+import { hasOwn, transformSource } from '@akashaorg/ui-awf-hooks';
+import { useGetProfileByDidQuery } from '@akashaorg/ui-awf-hooks/lib/generated/apollo';
+
+export type ProfileAvatarProps = {
+  profileDID: string;
+  href?: string;
+  metadata?: ReactElement;
+  truncateText?: boolean;
+  customStyle?: string;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+const ProfileAvatar = (props: ProfileAvatarProps) => {
+  const { profileDID, ...rest } = props;
+  const profileQuery = useGetProfileByDidQuery({
+    variables: { id: profileDID },
+    fetchPolicy: 'cache-first',
+  });
+
+  if (profileQuery?.loading) return <ProfileAvatarLoading />;
+
+  if (profileQuery?.error) return null;
+
+  const profileData =
+    profileQuery.data?.node && hasOwn(profileQuery.data.node, 'isViewer')
+      ? profileQuery.data.node.akashaProfile
+      : null;
+
+  return (
+    <ProfileAvatarButton
+      profileId={profileDID}
+      label={profileData.name}
+      avatar={transformSource(profileData?.avatar?.default)}
+      alternativeAvatars={profileData?.avatar?.alternatives?.map(alternative =>
+        transformSource(alternative),
+      )}
+      {...rest}
+    />
+  );
+};
+
+export default ProfileAvatar;

--- a/ui/apps/profile/src/index.tsx
+++ b/ui/apps/profile/src/index.tsx
@@ -36,6 +36,10 @@ export const register: (opts: IntegrationRegistrationOptions) => IAppConfig = op
       mountsIn: 'follow_*',
       loadingFn: () => import('./extensions/follow-profile-button'),
     },
+    {
+      mountsIn: 'profile_avatar_*',
+      loadingFn: () => import('./extensions/profile-avatar'),
+    },
   ],
   routes: {
     beams: routes[BEAMS],

--- a/ui/apps/profile/src/plugins/profile-plugin.ts
+++ b/ui/apps/profile/src/plugins/profile-plugin.ts
@@ -21,6 +21,7 @@ export class ProfilePlugin implements IProfilePlugin<AkashaProfile> {
       variables: {
         id: profileDID,
       },
+      fetchPolicy: 'cache-first',
     });
     const error = JSON.stringify(profileQuery.errors?.map(error => error.message));
     const profileData =

--- a/ui/apps/search/package.json
+++ b/ui/apps/search/package.json
@@ -36,6 +36,7 @@
     "@akashaorg/design-system-core": "*",
     "@akashaorg/ui-awf-hooks": "*",
     "@akashaorg/ui-lib-extensions": "*",
+    "@akashaorg/ui-lib-feed": "*",
     "i18next": "22.4.14",
     "i18next-browser-languagedetector": "7.0.1",
     "i18next-chained-backend": "4.2.0",

--- a/ui/apps/search/src/components/pages/entry-renderer.tsx
+++ b/ui/apps/search/src/components/pages/entry-renderer.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import sortBy from 'lodash/sortBy';
+import EntryCard from '@akashaorg/design-system-components/lib/components/Entry/EntryCard';
+import Stack from '@akashaorg/design-system-core/lib/components/Stack';
+import AuthorProfileAvatar from '@akashaorg/ui-lib-feed/lib/components/cards/author-profile-avatar';
 import { useTranslation } from 'react-i18next';
 import {
   EntityTypes,
@@ -7,17 +10,9 @@ import {
   Profile,
   IContentClickDetails,
 } from '@akashaorg/typings/lib/ui';
-import EntryCard from '@akashaorg/design-system-components/lib/components/Entry/EntryCard';
 import { Extension } from '@akashaorg/ui-lib-extensions/lib/react/extension';
 import { AkashaBeam } from '@akashaorg/typings/lib/sdk/graphql-types-new';
-import {
-  hasOwn,
-  mapBeamEntryData,
-  transformSource,
-  useGetLogin,
-  useRootComponentProps,
-} from '@akashaorg/ui-awf-hooks';
-import { useGetProfileByDidQuery } from '@akashaorg/ui-awf-hooks/lib/generated/apollo';
+import { mapBeamEntryData, useGetLogin, useRootComponentProps } from '@akashaorg/ui-awf-hooks';
 
 export type EntryCardRendererProps = {
   itemData?: AkashaBeam;
@@ -37,35 +32,12 @@ export type EntryCardRendererProps = {
 
 const EntryCardRenderer = (props: EntryCardRendererProps) => {
   const { itemData, itemType, contentClickable, navigateTo, onContentClick } = props;
-
   const { id } = itemData || {};
-
   const { t } = useTranslation('app-search');
-  const { getTranslationPlugin, navigateToModal } = useRootComponentProps();
+  const { navigateToModal } = useRootComponentProps();
   const { data } = useGetLogin();
   const authenticatedDID = data?.id;
   const isLoggedIn = !!data?.id;
-  const {
-    data: profileDataReq,
-    loading,
-    error,
-  } = useGetProfileByDidQuery({
-    variables: { id: itemData.author.id },
-  });
-
-  const { akashaProfile: profileData } =
-    profileDataReq?.node && hasOwn(profileDataReq.node, 'akashaProfile')
-      ? profileDataReq.node
-      : { akashaProfile: null };
-
-  const locale = getTranslationPlugin().i18n?.languages?.[0] || 'en';
-
-  const handleClickAvatar = () => {
-    navigateTo?.({
-      appName: '@akashaorg/app-profile',
-      getNavigationUrl: navRoutes => `${navRoutes.rootRoute}/${itemData?.author.id}`,
-    });
-  };
 
   const handleContentClick = () => {
     onContentClick(
@@ -99,19 +71,15 @@ const EntryCardRenderer = (props: EntryCardRendererProps) => {
   return (
     <>
       {itemData && itemData.author?.id && (
-        <div style={{ marginBottom: '8px' }}>
+        <Stack customStyle="mb-2">
           {!itemData.nsfw && itemData.active && (
             <EntryCard
               entryData={mapBeamEntryData(itemData)}
-              authorProfile={{ data: profileData, loading, error }}
               sortedContents={sortBy(itemData.content, 'order')}
               itemType={EntityTypes.BEAM}
-              onAvatarClick={handleClickAvatar}
               onContentClick={handleContentClick}
               flagAsLabel={t('Flag')}
-              locale={locale}
               moderatedContentLabel={t('This content has been moderated')}
-              profileAnchorLink={'/@akashaorg/app-profile'}
               reflectAnchorLink={`/@akashaorg/app-akasha-integration/${
                 itemType === EntityTypes.REFLECT ? 'reflection' : 'beam'
               }`}
@@ -122,13 +90,18 @@ const EntryCardRenderer = (props: EntryCardRendererProps) => {
               onEntryRemove={handleEntryRemove}
               onEntryFlag={handleFlag}
               hideActionButtons={hideActionButtons}
+              profileAvatarExt={
+                <AuthorProfileAvatar
+                  authorId={itemData.author.id}
+                  createdAt={itemData?.createdAt}
+                />
+              }
               actionsRight={<Extension name={`entry-card-actions-right_${id}`} />}
-              transformSource={transformSource}
             >
               {({ blockID }) => <Extension name={`${blockID}_content_block`} />}
             </EntryCard>
           )}
-        </div>
+        </Stack>
       )}
     </>
   );

--- a/ui/apps/vibes-console/package.json
+++ b/ui/apps/vibes-console/package.json
@@ -43,6 +43,7 @@
     "@akashaorg/design-system-components": "*",
     "@akashaorg/design-system-core": "*",
     "@akashaorg/ui-awf-hooks": "*",
+    "@akashaorg/ui-lib-feed": "*",
     "i18next": "22.4.14",
     "i18next-browser-languagedetector": "7.0.1",
     "i18next-chained-backend": "4.2.0",

--- a/ui/apps/vibes-console/src/utils/dummy-data.tsx
+++ b/ui/apps/vibes-console/src/utils/dummy-data.tsx
@@ -138,7 +138,7 @@ const entryData: EntryData = {
   id: 'kshggg55555',
 };
 
-const sampleEntryData: EntryCardProps = {
+export const sampleEntryData: EntryCardProps = {
   isLoggedIn: true,
   entryData,
   profileAvatarExt: (

--- a/ui/apps/vibes-console/src/utils/dummy-data.tsx
+++ b/ui/apps/vibes-console/src/utils/dummy-data.tsx
@@ -1,4 +1,6 @@
-import { EntityTypes } from '@akashaorg/typings/lib/ui';
+import React from 'react';
+import AuthorProfileAvatar from '@akashaorg/ui-lib-feed/lib/components/cards/author-profile-avatar';
+import { EntityTypes, EntryData } from '@akashaorg/typings/lib/ui';
 import { TApplicationStatus } from './status-color';
 import { EntryCardProps } from '@akashaorg/design-system-components/lib/components/Entry/EntryCard';
 import { ProfileItemData } from '@akashaorg/design-system-components/lib/components/VibesConsoleContentCard/mini-profile-cta';
@@ -129,22 +131,19 @@ type TReportEntry = {
   id: string;
 };
 
+const entryData: EntryData = {
+  active: true,
+  authorId: 'did:pkh:eip155:5:0xa2aabe32856a8d50c748d50a5111312d986208a8',
+  createdAt: '12/12/2023',
+  id: 'kshggg55555',
+};
+
 const sampleEntryData: EntryCardProps = {
   isLoggedIn: true,
-  entryData: {
-    active: true,
-    authorId: 'did:pkh:eip155:5:0xa2aabe32856a8d50c748d50a5111312d986208a8',
-    createdAt: '12/12/2023',
-    id: 'kshggg55555',
-  },
-  authorProfile: {
-    data: {
-      did: { id: 'did:pkh:eip155:5:0xa2aabe32856a8d50c748d50a5111312d986208a8' },
-      name: 'Coffee Lover',
-    },
-    loading: false,
-    error: new Error('an error occured'),
-  },
+  entryData,
+  profileAvatarExt: (
+    <AuthorProfileAvatar authorId={entryData.authorId} createdAt={entryData?.createdAt} />
+  ),
   itemType: EntityTypes?.REFLECT,
   flagAsLabel: 'Flag',
   slateContent: [
@@ -160,11 +159,6 @@ const sampleEntryData: EntryCardProps = {
   onContentClick: () => ({}),
   onMentionClick: () => ({}),
   onTagClick: () => ({}),
-  transformSource: () => ({
-    src: 'https://placebeard.it/360x360',
-    width: 360,
-    height: 360,
-  }),
 };
 
 const sampleProfileData: ProfileItemData = {

--- a/ui/design-system-components/src/components/Entry/EntryCard/index.tsx
+++ b/ui/design-system-components/src/components/Entry/EntryCard/index.tsx
@@ -1,34 +1,20 @@
 import React, { ReactElement, ReactNode, Ref, Fragment, useState } from 'react';
 import Card from '@akashaorg/design-system-core/lib/components/Card';
 import Stack from '@akashaorg/design-system-core/lib/components/Stack';
-import ProfileAvatarButton from '@akashaorg/design-system-core/lib/components/ProfileAvatarButton';
-import Tooltip from '@akashaorg/design-system-core/lib/components/Tooltip';
 import EntryCardRemoved, { AuthorsRemovedMessage, OthersRemovedMessage } from '../EntryCardRemoved';
 import CardActions from './card-actions';
-import Text from '@akashaorg/design-system-core/lib/components/Text';
 import {
   EllipsisHorizontalIcon,
   FlagIcon,
   PencilIcon,
 } from '@akashaorg/design-system-core/lib/components/Icon/hero-icons-outline';
 import ReadOnlyEditor from '../../ReadOnlyEditor';
-import AuthorProfileLoading from '../EntryCardLoading/author-profile-loading';
 import NSFW, { NSFWProps } from '../NSFW';
 import Menu from '@akashaorg/design-system-core/lib/components/Menu';
-import {
-  formatDate,
-  formatRelativeTime,
-  getColorClasses,
-} from '@akashaorg/design-system-core/lib/utils';
+import { getColorClasses } from '@akashaorg/design-system-core/lib/utils';
 import { Descendant } from 'slate';
 import { AkashaBeam } from '@akashaorg/typings/lib/sdk/graphql-types-new';
-import {
-  type EntryData,
-  AkashaProfile,
-  EntityTypes,
-  type Image,
-  NavigateToParams,
-} from '@akashaorg/typings/lib/ui';
+import { type EntryData, EntityTypes, NavigateToParams } from '@akashaorg/typings/lib/ui';
 import { ListItem } from '@akashaorg/design-system-core/lib/components/List';
 import Pill from '@akashaorg/design-system-core/lib/components/Pill';
 import ErrorBoundary, {
@@ -49,12 +35,7 @@ type ReflectProps = {
 
 export type EntryCardProps = {
   entryData: EntryData;
-  authorProfile: {
-    data: Pick<AkashaProfile, 'name' | 'avatar' | 'did'>;
-    loading: boolean;
-    error: Error;
-  };
-  locale?: string;
+  profileAvatarExt: ReactNode;
   flagAsLabel?: string;
   moderatedContentLabel?: string;
   ctaLabel?: string;
@@ -66,12 +47,10 @@ export type EntryCardProps = {
   };
   editLabel?: string;
   nsfw?: Omit<NSFWProps, 'onClickToView'>;
-  profileAnchorLink?: string;
   reflectAnchorLink?: string;
   disableReporting?: boolean;
   isViewer?: boolean;
   isLoggedIn: boolean;
-  hidePublishTime?: boolean;
   disableActions?: boolean;
   noWrapperCard?: boolean;
   hideActionButtons?: boolean;
@@ -86,7 +65,6 @@ export type EntryCardProps = {
   customStyle?: string;
   ref?: Ref<HTMLDivElement>;
   onReflect?: () => void;
-  onAvatarClick?: (profileId: string) => void;
   onTagClick?: (tag: string) => void;
   onMentionClick?: (profileId: string) => void;
   onContentClick?: () => void;
@@ -94,26 +72,22 @@ export type EntryCardProps = {
   onEntryFlag?: () => void;
   onEdit?: () => void;
   showLoginModal?: (title?: string, message?: string) => void;
-  transformSource: (src: Image) => Image;
 } & (BeamProps | ReflectProps);
 
 const EntryCard: React.FC<EntryCardProps> = props => {
   const {
     entryData,
-    locale,
+    profileAvatarExt,
     ref,
-    authorProfile,
     flagAsLabel,
     removed,
     notEditableLabel,
     editLabel,
     nsfw,
-    profileAnchorLink,
     reflectAnchorLink,
     disableReporting,
     isViewer,
     isLoggedIn,
-    hidePublishTime,
     disableActions,
     noWrapperCard = false,
     hideActionButtons,
@@ -126,18 +100,14 @@ const EntryCard: React.FC<EntryCardProps> = props => {
     actionsRight,
     reflectionsCount,
     customStyle,
-    onAvatarClick,
     onTagClick,
     onContentClick,
     onEntryFlag,
     onReflect,
     onEdit,
-    transformSource,
     showLoginModal,
     ...rest
   } = props;
-
-  const profileRef: React.Ref<HTMLDivElement> = React.useRef(null);
 
   /* showNSFWContent determines whether to display the content underneath the
    * overlay, so if the showNSFWCard prop is true (which means to show the
@@ -176,8 +146,6 @@ const EntryCard: React.FC<EntryCardProps> = props => {
   const hoverStyle = hover
     ? `${getColorClasses({ light: 'grey9/60', dark: 'grey3' }, 'hover:bg')} ${hoverStyleLastEntry}`
     : '';
-  const publishTime = entryData?.createdAt ? formatRelativeTime(entryData.createdAt, locale) : '';
-  const avatar = authorProfile.error ? null : authorProfile.data?.avatar;
 
   const errorBoundaryProps: Pick<ErrorBoundaryProps, 'errorObj' | 'logger'> = {
     errorObj: {
@@ -189,53 +157,7 @@ const EntryCard: React.FC<EntryCardProps> = props => {
   const entryCardUi = (
     <Stack spacing="gap-y-2" padding="p-4" customStyle={hoverStyle}>
       <Stack direction="row" justify="between">
-        <>
-          {authorProfile.loading ? (
-            <AuthorProfileLoading />
-          ) : (
-            <ProfileAvatarButton
-              data-testid="entry-profile-detail"
-              profileId={entryData.authorId}
-              label={authorProfile.error ? entryData.authorId : authorProfile.data?.name}
-              avatar={transformSource(avatar?.default)}
-              alternativeAvatars={avatar?.alternatives?.map(alternative =>
-                transformSource(alternative),
-              )}
-              href={`${profileAnchorLink}/${entryData.authorId}`}
-              metadata={
-                publishTime &&
-                !hidePublishTime && (
-                  <Stack direction="row" align="center" spacing="gap-x-1">
-                    <Text
-                      variant="footnotes2"
-                      weight="normal"
-                      color={{ light: 'grey4', dark: 'grey7' }}
-                    >
-                      ·
-                    </Text>
-                    <Tooltip
-                      placement={'top'}
-                      content={formatDate(entryData?.createdAt, 'H[:]mm [·] D MMM YYYY', locale)}
-                    >
-                      <Text
-                        variant="footnotes2"
-                        weight="normal"
-                        color={{ light: 'grey4', dark: 'grey7' }}
-                      >
-                        {publishTime}
-                      </Text>
-                    </Tooltip>
-                  </Stack>
-                )
-              }
-              onClick={() => {
-                if (onAvatarClick) onAvatarClick(entryData.authorId);
-              }}
-              ref={profileRef}
-            />
-          )}
-        </>
-
+        {profileAvatarExt}
         <Menu
           anchor={{
             icon: <EllipsisHorizontalIcon />,

--- a/ui/design-system-components/src/components/Entry/EntryCardLoading/index.tsx
+++ b/ui/design-system-components/src/components/Entry/EntryCardLoading/index.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren } from 'react';
 import Card from '@akashaorg/design-system-core/lib/components/Card';
 import TextLine from '@akashaorg/design-system-core/lib/components/TextLine';
 import Stack from '@akashaorg/design-system-core/lib/components/Stack';
-import AuthorProfileLoading from './author-profile-loading';
+import ProfileAvatarLoading from '@akashaorg/design-system-core/lib/components/ProfileAvatarButton/ProfileAvatarLoading';
 
 export type EntryLoadingPlaceholderProps = {
   animated?: boolean;
@@ -16,7 +16,7 @@ const EntryLoadingPlaceholder: React.FC<
   const loaderUi = (
     <Stack spacing="gap-y-2" padding="p-4">
       <Stack direction="row" align="center" justify="between">
-        <AuthorProfileLoading animated={animated} />
+        <ProfileAvatarLoading animated={animated} />
         <TextLine width="w-4" height="h-4" animated={animated} />
       </Stack>
       <Stack justify="center" spacing="gap-y-1">

--- a/ui/design-system-components/tsconfig.json
+++ b/ui/design-system-components/tsconfig.json
@@ -8,6 +8,9 @@
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx"
   },
-  "include": ["./src/**/*"],
+  "include": [
+    "./src/**/*",
+    "../design-system-core/src/components/ProfileAvatarButton/profile-avatar-loading.tsx"
+  ],
   "exclude": ["**/*.test.tsx", "./src/stories/**/*"]
 }

--- a/ui/design-system-core/src/components/ProfileAvatarButton/ProfileAvatarLoading/index.tsx
+++ b/ui/design-system-core/src/components/ProfileAvatarButton/ProfileAvatarLoading/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Stack from '@akashaorg/design-system-core/lib/components/Stack';
-import TextLine from '@akashaorg/design-system-core/lib/components/TextLine';
+import Stack from '../../Stack';
+import TextLine from '../../TextLine';
 
-type AuthorProfileLoadingProps = {
+type ProfileAvatarLoadingProps = {
   animated?: boolean;
 };
 
-const AuthorProfileLoading: React.FC<AuthorProfileLoadingProps> = props => {
+const ProfileAvatarLoading: React.FC<ProfileAvatarLoadingProps> = props => {
   const { animated = false } = props;
   return (
     <Stack direction="row" spacing="gap-1">
@@ -25,4 +25,4 @@ const AuthorProfileLoading: React.FC<AuthorProfileLoadingProps> = props => {
   );
 };
 
-export default AuthorProfileLoading;
+export default ProfileAvatarLoading;

--- a/ui/design-system-core/src/components/ProfileAvatarButton/__tests__/index.test.tsx
+++ b/ui/design-system-core/src/components/ProfileAvatarButton/__tests__/index.test.tsx
@@ -18,7 +18,6 @@ describe('<ProfileAvatarButton /> Component', () => {
   };
 
   const handleClick = jest.fn(/** */);
-  const handleClickAvatar = jest.fn(/** */);
 
   beforeEach(() => {
     act(() => {
@@ -57,11 +56,8 @@ describe('<ProfileAvatarButton /> Component', () => {
 
     const avatarBox = getByTestId('avatar-box');
     expect(avatarBox.childNodes[0]).toBeDefined();
-    expect(handleClickAvatar).toBeCalledTimes(0);
 
     fireEvent.click(avatarBox.childNodes[0]);
-
-    expect(handleClickAvatar).toBeCalledTimes(1);
   });
 
   it('calls info handlers', () => {

--- a/ui/design-system-core/src/components/ProfileAvatarButton/__tests__/index.test.tsx
+++ b/ui/design-system-core/src/components/ProfileAvatarButton/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { act, fireEvent } from '@testing-library/react';
 import ProfileAvatarButton from '../';
+import { act, fireEvent } from '@testing-library/react';
 import { customRender } from '../../../test-utils';
 import { truncateDid } from '../../../utils';
 
@@ -19,8 +19,6 @@ describe('<ProfileAvatarButton /> Component', () => {
 
   const handleClick = jest.fn(/** */);
   const handleClickAvatar = jest.fn(/** */);
-  const handleMouseEnter = jest.fn(/** */);
-  const handleMouseLeave = jest.fn(/** */);
 
   beforeEach(() => {
     act(() => {
@@ -30,9 +28,6 @@ describe('<ProfileAvatarButton /> Component', () => {
           avatar={avatar}
           profileId={profileId}
           onClick={handleClick}
-          onClickAvatar={handleClickAvatar}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
         />,
         {},
       );
@@ -75,16 +70,12 @@ describe('<ProfileAvatarButton /> Component', () => {
     const infoBox = getByTestId('info-box');
     expect(infoBox).toBeDefined();
     expect(handleClick).toBeCalledTimes(0);
-    expect(handleMouseEnter).toBeCalledTimes(0);
-    expect(handleMouseLeave).toBeCalledTimes(0);
 
     fireEvent.mouseEnter(infoBox);
-    expect(handleMouseEnter).toBeCalledTimes(1);
 
     fireEvent.click(infoBox);
     expect(handleClick).toBeCalledTimes(1);
 
     fireEvent.mouseLeave(infoBox);
-    expect(handleMouseLeave).toBeCalledTimes(1);
   });
 });

--- a/ui/design-system-core/src/components/ProfileAvatarButton/index.tsx
+++ b/ui/design-system-core/src/components/ProfileAvatarButton/index.tsx
@@ -17,9 +17,6 @@ export type ProfileAvatarButtonProps = {
   href?: string;
   metadata?: ReactElement;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  onClickAvatar?: () => void;
-  onMouseEnter?: React.MouseEventHandler<HTMLButtonElement>;
-  onMouseLeave?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 const ProfileAvatarButton = React.forwardRef(
@@ -34,26 +31,13 @@ const ProfileAvatarButton = React.forwardRef(
       href,
       metadata,
       onClick,
-      onClickAvatar,
-      onMouseEnter,
-      onMouseLeave,
     } = props;
-
-    const handleClickAvatar = ev => {
-      ev.preventDefault();
-
-      if (onClickAvatar) {
-        onClickAvatar();
-      }
-    };
 
     return (
       <Button
         plain={true}
         customStyle={`inline-flex items-center space-x-2 ${customStyle}`}
         onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
       >
         <Stack customStyle="shrink-0" testId="avatar-box" aria-label="avatar-box">
           <Avatar
@@ -62,7 +46,6 @@ const ProfileAvatarButton = React.forwardRef(
             profileId={profileId}
             customStyle="cursor-pointer"
             href={href}
-            onClick={handleClickAvatar}
           />
         </Stack>
         <Stack

--- a/ui/hooks/src/store/user-store.ts
+++ b/ui/hooks/src/store/user-store.ts
@@ -18,14 +18,10 @@ export class UserStore<T> implements IUserStore<T> {
     authenticatedProfileError: null,
     isAuthenticating: false,
     authenticationError: null,
-    isLoadingInfo: false,
-    info: {},
-    infoError: null,
   };
   #sdk = getSDK();
   static #instance = null;
   #getProfileInfo: IGetProfileInfo<T>['getProfileInfo'];
-  //
   #userAtom = atomWithImmer<IUserState<T>>(this.#initialState);
 
   /**
@@ -76,33 +72,6 @@ export class UserStore<T> implements IUserStore<T> {
   logout = () => {
     this.#sdk.api.auth.signOut();
     store.set(this.#userAtom, () => this.#initialState);
-  };
-
-  /**
-   * Fetch user info using getProfileInfo method from the profile app plugin
-   */
-  getUserInfo = async ({ profileDID }) => {
-    store.set(this.#userAtom, prev => ({
-      ...prev,
-      isLoadingInfo: true,
-    }));
-    try {
-      const { data: profileInfo, error } = await this.#getProfileInfo({ profileDID });
-      const state = store.get(this.#userAtom);
-      const info = profileInfo ? { ...state.info, [profileDID]: profileInfo } : null;
-      store.set(this.#userAtom, prev => ({
-        ...prev,
-        info,
-        isLoadingInfo: false,
-        infoError: error,
-      }));
-    } catch (error) {
-      store.set(this.#userAtom, prev => ({
-        ...prev,
-        infoError: error,
-        isLoadingInfo: false,
-      }));
-    }
   };
 
   /**

--- a/ui/lib/feed/src/components/cards/author-profile-avatar/index.tsx
+++ b/ui/lib/feed/src/components/cards/author-profile-avatar/index.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import Stack from '@akashaorg/design-system-core/lib/components/Stack';
+import Text from '@akashaorg/design-system-core/lib/components/Text';
+import Tooltip from '@akashaorg/design-system-core/lib/components/Tooltip';
+import ProfileAvatarLoading from '@akashaorg/design-system-core/lib/components/ProfileAvatarButton/ProfileAvatarLoading';
+import { Extension } from '@akashaorg/ui-lib-extensions/lib/react/extension';
+import { formatDate, formatRelativeTime } from '@akashaorg/design-system-core/lib/utils';
+import { useRootComponentProps } from '@akashaorg/ui-awf-hooks';
+
+type AuthorProfileAvatarProps = {
+  authorId: string;
+  createdAt: string;
+  hidePublishTime?: boolean;
+};
+
+const AuthorProfileAvatar: React.FC<AuthorProfileAvatarProps> = props => {
+  const { authorId, createdAt, hidePublishTime } = props;
+  const { getTranslationPlugin, getRoutingPlugin } = useRootComponentProps();
+  const navigateTo = getRoutingPlugin().navigateTo;
+  const locale = getTranslationPlugin().i18n?.languages?.[0] || 'en';
+  const publishTime = createdAt ? formatRelativeTime(createdAt, locale) : '';
+
+  const onAvatarClick = (id: string) => {
+    navigateTo({
+      appName: '@akashaorg/app-profile',
+      getNavigationUrl: routes => `${routes.rootRoute}/${id}`,
+    });
+  };
+
+  return (
+    <Extension
+      name={`profile_avatar_${authorId}`}
+      loadingIndicator={<ProfileAvatarLoading />}
+      emptyIndicator={<ProfileAvatarLoading />}
+      extensionData={{
+        dataTestId: 'entry-profile-detail',
+        profileDID: authorId,
+        href: `/@akashaorg/app-profile/${authorId}`,
+        metadata: (
+          <>
+            {publishTime && !hidePublishTime && (
+              <Stack direction="row" align="center" spacing="gap-x-1">
+                <Text
+                  variant="footnotes2"
+                  weight="normal"
+                  color={{ light: 'grey4', dark: 'grey7' }}
+                >
+                  ·
+                </Text>
+                <Tooltip
+                  placement={'top'}
+                  content={createdAt ? formatDate(createdAt, 'H[:]mm [·] D MMM YYYY', locale) : ''}
+                >
+                  <Text
+                    variant="footnotes2"
+                    weight="normal"
+                    color={{ light: 'grey4', dark: 'grey7' }}
+                  >
+                    {publishTime}
+                  </Text>
+                </Tooltip>
+              </Stack>
+            )}
+          </>
+        ),
+        onClick: () => {
+          onAvatarClick(authorId);
+        },
+      }}
+    />
+  );
+};
+
+export default AuthorProfileAvatar;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- extract profile info in beam card to an extension
- remove public method `getUserInfo` and `info` states from the user store(after trying to use it on this PR it's observed that this method introduces unnecessary complexity in making it work correctly and after all the toil it doesn't provide much value. Devs can just use the existing apollo hooks to fetch profile info as needed).

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
