### PR TITLE
fix(): session restoration bug on page reload

### DIFF
--- a/libs/app-loader/src/index.ts
+++ b/libs/app-loader/src/index.ts
@@ -112,9 +112,6 @@ export default class AppLoader {
     this.renderLayout();
 
     this.listenGlobalChannel().catch();
-    // automatic logging in if previous session is detected
-    const sdk = getSDK();
-    await sdk.api.auth.getCurrentUser();
   };
   onBeforeFirstMount = () => hidePageSplash();
   onFirstMount = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- fix session restoration bug on page reload
- the pr doesn't address the web3modal that appears once in awhile on page reload and remains active even if the authentication session is restored

![image](https://github.com/user-attachments/assets/65311bcd-8f5e-4cbf-8ba2-66a3198e13fe)

## Issues that will be closed
<!--- Add #issueNumber here -->



## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
