### PR TITLE
fix(profile-app): prevent edit and delete menu options showing for empty images

### DIFF
--- a/extensions/apps/profile/src/components/pages/edit-profile/get-profile-images.ts
+++ b/extensions/apps/profile/src/components/pages/edit-profile/get-profile-images.ts
@@ -4,29 +4,27 @@ import {
 } from '@akashaorg/typings/lib/sdk/graphql-types-new';
 
 export const getAvatarImage = (
-  newAvatarImage: ProfileImageVersions,
+  newAvatarImage: ProfileImageVersions | undefined,
   isImageDeleted: boolean,
 ): Pick<PartialAkashaProfileInput, 'avatar'> => {
-  if (newAvatarImage) {
-    return { avatar: newAvatarImage };
-  }
   if (isImageDeleted) {
     return { avatar: null };
   }
-  //empty object implies avatar image hasn't changed
-  return {};
+  return newAvatarImage
+    ? { avatar: newAvatarImage }
+    : //empty object implies avatar image hasn't changed
+      {};
 };
 
 export const getCoverImage = (
-  newCoverImage: ProfileImageVersions,
+  newCoverImage: ProfileImageVersions | undefined,
   isImageDeleted: boolean,
 ): Pick<PartialAkashaProfileInput, 'background'> => {
-  if (newCoverImage) {
-    return { background: newCoverImage };
-  }
   if (isImageDeleted) {
     return { background: null };
   }
-  //empty object implies cover image hasn't changed
-  return {};
+  return newCoverImage
+    ? { background: newCoverImage }
+    : //empty object implies cover image hasn't changed
+      {};
 };

--- a/extensions/apps/profile/src/components/pages/edit-profile/get-profile-images.ts
+++ b/extensions/apps/profile/src/components/pages/edit-profile/get-profile-images.ts
@@ -4,7 +4,7 @@ import {
 } from '@akashaorg/typings/lib/sdk/graphql-types-new';
 
 export const getAvatarImage = (
-  newAvatarImage: ProfileImageVersions | undefined,
+  newAvatarImage: ProfileImageVersions | null,
   isImageDeleted: boolean,
 ): Pick<PartialAkashaProfileInput, 'avatar'> => {
   if (isImageDeleted) {
@@ -17,7 +17,7 @@ export const getAvatarImage = (
 };
 
 export const getCoverImage = (
-  newCoverImage: ProfileImageVersions | undefined,
+  newCoverImage: ProfileImageVersions | null,
   isImageDeleted: boolean,
 ): Pick<PartialAkashaProfileInput, 'background'> => {
   if (isImageDeleted) {

--- a/libs/design-system-components/src/components/EditProfile/General/Header/index.tsx
+++ b/libs/design-system-components/src/components/EditProfile/General/Header/index.tsx
@@ -103,6 +103,8 @@ export const Header: React.FC<HeaderProps> = ({
     }
   };
 
+  const showEditAndDelete = profileImageType === 'avatar' ? !!avatarUrl : !!coverImageUrl;
+
   const dropDownActions: ListProps['items'] = [
     {
       label: 'Upload',
@@ -112,23 +114,27 @@ export const Header: React.FC<HeaderProps> = ({
         closeActionsDropDown();
       },
     },
-    {
-      label: 'Edit',
-      icon: <PencilIcon />,
-      onClick: () => {
-        setShowEditImage(true);
-        closeActionsDropDown();
-      },
-    },
-    {
-      label: 'Delete',
-      icon: <TrashIcon />,
-      color: { light: 'errorLight', dark: 'errorDark' },
-      onClick: () => {
-        setShowDeleteImage(true);
-        closeActionsDropDown();
-      },
-    },
+    ...(showEditAndDelete
+      ? [
+          {
+            label: 'Edit',
+            icon: <PencilIcon />,
+            onClick: () => {
+              setShowEditImage(true);
+              closeActionsDropDown();
+            },
+          },
+          {
+            label: 'Delete',
+            icon: <TrashIcon />,
+            color: { light: 'errorLight', dark: 'errorDark' } as const,
+            onClick: () => {
+              setShowDeleteImage(true);
+              closeActionsDropDown();
+            },
+          },
+        ]
+      : []),
   ];
 
   const imageModalProps: Partial<CropperProps> =

--- a/libs/design-system-components/src/components/EditProfile/General/Header/index.tsx
+++ b/libs/design-system-components/src/components/EditProfile/General/Header/index.tsx
@@ -103,7 +103,9 @@ export const Header: React.FC<HeaderProps> = ({
     }
   };
 
-  const showEditAndDelete = profileImageType === 'avatar' ? !!avatarUrl : !!coverImageUrl;
+  const showEditAndDeleteMenuOptions =
+    (profileImageType === 'avatar' && !!avatarUrl) ||
+    (profileImageType === 'cover-image' && !!coverImageUrl);
 
   const dropDownActions: ListProps['items'] = [
     {
@@ -114,7 +116,7 @@ export const Header: React.FC<HeaderProps> = ({
         closeActionsDropDown();
       },
     },
-    ...(showEditAndDelete
+    ...(showEditAndDeleteMenuOptions
       ? [
           {
             label: 'Edit',

--- a/libs/design-system-components/src/components/EditProfile/index.tsx
+++ b/libs/design-system-components/src/components/EditProfile/index.tsx
@@ -72,6 +72,7 @@ const EditProfile: React.FC<EditProfileProps> = ({
   const onSave = (event: SyntheticEvent) => {
     event.preventDefault();
     const formValues = getValues();
+
     if (isValid && isFormDirty) {
       saveButton.handleClick({
         ...formValues,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- prevent edit and delete menu options showing for avatar and cover image placeholders

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
