### PR TITLE
fix(): image fields sent to server while creating new profile

### DIFF
--- a/extensions/apps/profile/src/components/pages/edit-profile/index.tsx
+++ b/extensions/apps/profile/src/components/pages/edit-profile/index.tsx
@@ -153,11 +153,12 @@ const EditProfilePage: React.FC<EditProfilePageProps> = props => {
   };
 
   const onProfileSave = async (publishProfileData: PublishProfileData) => {
+    const isNewProfile = !profileData?.id;
     const profileImages = {
-      ...getAvatarImage(newAvatarImage, !publishProfileData.avatar),
-      ...getCoverImage(newCoverImage, !publishProfileData.coverImage),
+      ...getAvatarImage(newAvatarImage, isNewProfile ? false : !publishProfileData.avatar),
+      ...getCoverImage(newCoverImage, isNewProfile ? false : !publishProfileData.coverImage),
     };
-    if (!profileData?.id) {
+    if (isNewProfile) {
       await createProfile(publishProfileData, profileImages);
       return;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The PR fixes a bug where null values were sent for avatar and background fields when creating new profiles without uploading images


## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
