### PR TITLE
fix(): issue with uploading same image consecutively

### DIFF
--- a/extensions/apps/antenna/src/extensions/image-block/image-editor-block.tsx
+++ b/extensions/apps/antenna/src/extensions/image-block/image-editor-block.tsx
@@ -298,6 +298,7 @@ export const ImageEditorBlock = (
         size: uploadedImage?.size,
       },
     ]);
+    uploadInputRef.current.value = null;
   };
 
   const uploadEditedImage = async (image: File, indexOfEditedImage: number) => {

--- a/libs/design-system-components/src/components/EditProfile/General/Header/index.tsx
+++ b/libs/design-system-components/src/components/EditProfile/General/Header/index.tsx
@@ -184,6 +184,7 @@ export const Header: React.FC<HeaderProps> = ({
       }
       setShowEditImage(true);
     }
+    uploadInputRef.current.value = null;
   };
 
   return (

--- a/libs/design-system-components/src/components/ExtensionEditStep2Form/Gallery/index.tsx
+++ b/libs/design-system-components/src/components/ExtensionEditStep2Form/Gallery/index.tsx
@@ -82,7 +82,10 @@ export const Gallery: React.FC<GalleryProps> = props => {
         ref={uploadInputRef}
         type="file"
         accept="image/png, image/jpeg, image/webp"
-        onChange={e => handleImageUpload(e.target.files[0])}
+        onChange={e => {
+          handleImageUpload(e.target.files[0]);
+          uploadInputRef.current.value = null;
+        }}
         hidden
       />
     </Stack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Issues that will be closed
<!--- Add #issueNumber here -->

- currently uploading the same image consecutively doesn't work in the following places :
  - beam editor image upload
  - edit profile image upload
  - extensions gallery upload

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
