### PR TITLE
remove systemjs delete before unload logic

### DIFF
--- a/libs/app-loader/src/index.ts
+++ b/libs/app-loader/src/index.ts
@@ -744,18 +744,16 @@ export default class AppLoader {
     extensionInfo: AkashaApp,
     extensionModule: SystemModuleType,
     extensionConfig: IAppConfig & { name: string },
-    isDevMode = false,
   ) => {
     this.extensionModules.set(extensionInfo.name, extensionModule);
     this.extensionConfigs.set(extensionInfo.name, extensionConfig);
     this.extensionData.push(extensionInfo);
     this.registerAdditionalEntities(extensionConfig, extensionInfo.applicationType);
-    this.singleSpaRegister(new Map().set(extensionInfo.name, extensionConfig), isDevMode);
+    this.singleSpaRegister(new Map().set(extensionInfo.name, extensionConfig));
   };
 
   singleSpaRegister = (
-    extensionConfigs: Map<string, IAppConfig & { name: string }>,
-    isDevMode = false,
+    extensionConfigs: Map<string, IAppConfig & { name: string }>
   ) => {
     for (const [name, conf] of extensionConfigs) {
       const logger = this.parentLogger.create(name);
@@ -802,7 +800,6 @@ export default class AppLoader {
         name,
         app: () =>
           createLoadingFunction(conf.rootComponent, conf.UILib, {
-            deleteSourcesOnUnmount: isDevMode,
             logger,
             onRenderError: () => {
               showError({

--- a/libs/app-loader/src/loading-functions/index.ts
+++ b/libs/app-loader/src/loading-functions/index.ts
@@ -1,11 +1,6 @@
 import { IAppConfig, IRootComponentProps, SupportedUILibs } from '@akashaorg/typings/lib/ui';
 
 export type LoadingFunctionOptions = {
-  /**
-   *  when true, the sources will also be removed when the app unmounts
-   *  useful in hmr.
-   */
-  deleteSourcesOnUnmount?: boolean;
   logger: IRootComponentProps['logger'];
   /**
    * Called when the application failed to render due to an error

--- a/libs/app-loader/src/loading-functions/react.ts
+++ b/libs/app-loader/src/loading-functions/react.ts
@@ -6,7 +6,7 @@ import { LoadingFunctionOptions } from './index';
 
 export const getLifecycles = (
   rootComponent: IAppConfig['rootComponent'],
-  { deleteSourcesOnUnmount, onRenderError, onModuleError }: LoadingFunctionOptions,
+  { onRenderError, onModuleError }: LoadingFunctionOptions,
 ) => {
   const lifecycles = singleSpaReact({
     React,
@@ -41,12 +41,7 @@ export const getLifecycles = (
   return {
     bootstrap: lifecycles.bootstrap,
     mount: lifecycles.mount,
-    unmount: (props: IRootComponentProps) => {
-      if (deleteSourcesOnUnmount && System.has(props.name)) {
-        System.delete(System.resolve(props.name));
-      }
-      return lifecycles.unmount(props);
-    },
+    unmount: lifecycles.unmount,
     update: lifecycles.update,
   };
 };

--- a/libs/app-loader/src/plugins/test-mode-loader.ts
+++ b/libs/app-loader/src/plugins/test-mode-loader.ts
@@ -172,7 +172,6 @@ export class TestModeLoader implements ITestModeLoaderPlugin {
           },
           extensionModule,
           extensionConfig,
-          true,
         );
         this.#notifyCurrentStatus(this.getStaticStatusCodes().status.EXTENSION_TEST_LOAD_SUCCESS);
       } else {


### PR DESCRIPTION
Removing systemjs delete before app unload. 
app-loader should not be bloated with this type of logic.
Handling is now moved to devkit's hmr logic.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
