### PR TITLE
chore(): change default type of button component

### DIFF
--- a/libs/design-system-components/src/components/ExtensionEditPublishedForm/index.tsx
+++ b/libs/design-system-components/src/components/ExtensionEditPublishedForm/index.tsx
@@ -253,7 +253,7 @@ const ExtensionEditPublishedForm: React.FC<ExtensionEditPublishedFormProps> = pr
           >
             {cancelButton.label}
           </Button>
-          <Button loading={loading} disabled={!isValid || loading} onClick={onSave}>
+          <Button loading={loading} disabled={!isValid || loading} onClick={onSave} type="submit">
             {nextButton.label}
           </Button>
         </Stack>

--- a/libs/design-system-components/src/components/ExtensionEditStep1Form/index.tsx
+++ b/libs/design-system-components/src/components/ExtensionEditStep1Form/index.tsx
@@ -169,7 +169,7 @@ const ExtensionEditStep1Form: React.FC<ExtensionEditStep1FormProps> = props => {
           >
             {cancelButton.label}
           </Button>
-          <Button disabled={!isValid || loading} onClick={onSave}>
+          <Button disabled={!isValid || loading} onClick={onSave} type="submit">
             {nextButton.label}
           </Button>
         </Stack>

--- a/libs/design-system-components/src/components/ExtensionEditStep2Form/index.tsx
+++ b/libs/design-system-components/src/components/ExtensionEditStep2Form/index.tsx
@@ -172,7 +172,7 @@ const ExtensionEditStep2Form: React.FC<ExtensionEditStep2FormProps> = props => {
           >
             {cancelButton.label}
           </Button>
-          <Button disabled={!isValid} onClick={onSave}>
+          <Button disabled={!isValid} onClick={onSave} type="submit">
             {nextButton.label}
           </Button>
         </Stack>

--- a/libs/design-system-components/src/components/ExtensionEditStep3Form/index.tsx
+++ b/libs/design-system-components/src/components/ExtensionEditStep3Form/index.tsx
@@ -335,7 +335,7 @@ const ExtensionEditStep3Form: React.FC<ExtensionEditStep3FormProps> = props => {
           >
             {cancelButton.label}
           </Button>
-          <Button disabled={!isValid} onClick={onSave}>
+          <Button disabled={!isValid} onClick={onSave} type="submit">
             {nextButton.label}
           </Button>
         </Stack>

--- a/libs/design-system-components/src/components/ExtensionReleasePublishForm/index.tsx
+++ b/libs/design-system-components/src/components/ExtensionReleasePublishForm/index.tsx
@@ -216,6 +216,7 @@ const ExtensionReleasePublish: React.FC<ExtensionReleasePublishProps> = props =>
               loading={loading}
               disabled={!isValid || !isFormDirty}
               onClick={showModalFlow ? onConfirmationModalOpen : onSave}
+              type="submit"
             >
               {nextButton.label}
             </Button>

--- a/libs/ui/src/akasha-components/button.tsx
+++ b/libs/ui/src/akasha-components/button.tsx
@@ -39,6 +39,7 @@ function Button({
   size = 'default',
   loading,
   asChild = false,
+  type = 'button',
   disabled,
   children,
   ...props
@@ -60,6 +61,7 @@ function Button({
         buttonVariants({ variant, size, className }),
         { 'p-0': variant === 'link' || asChild },
       )}
+      type={type}
       disabled={loading || disabled}
       {...props}
     >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- non submit buttons inside a form are triggering validation on a form, and to fix this the default type of button component is set as `button` 

## Issues that will be closed
<!--- Add #issueNumber here -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Screenshots -->

## Checklist

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)
